### PR TITLE
fix: wrap PowerShellToolRunner.psPath in ""

### DIFF
--- a/lib/PowerShell/Utilities/PowerShellToolRunner.js
+++ b/lib/PowerShell/Utilities/PowerShellToolRunner.js
@@ -28,7 +28,7 @@ class PowerShellToolRunner {
     }
     static executePowerShellScriptBlock(scriptBlock, options = {}) {
         return __awaiter(this, void 0, void 0, function* () {
-            yield exec.exec(`${PowerShellToolRunner.psPath} -Command`, [scriptBlock], options);
+            yield exec.exec(`"${PowerShellToolRunner.psPath}" -Command`, [scriptBlock], options);
         });
     }
 }

--- a/src/PowerShell/Utilities/PowerShellToolRunner.ts
+++ b/src/PowerShell/Utilities/PowerShellToolRunner.ts
@@ -11,6 +11,6 @@ export default class PowerShellToolRunner {
     }
 
     static async executePowerShellScriptBlock(scriptBlock: string, options: any = {}) {
-        await exec.exec(`${PowerShellToolRunner.psPath} -Command`, [scriptBlock], options)
+        await exec.exec(`"${PowerShellToolRunner.psPath}" -Command`, [scriptBlock], options)
     }
 }


### PR DESCRIPTION
This PR closes #30 

Had to wrap `${PowerShellToolRunner.psPath}`around quotes. It appears `exec.exec` does not like spaces in the path.