### PR TITLE
Adding support to other Azure Cloud

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
   creds:
     description: 'Paste output of `az ad sp create-for-rbac` as value of secret variable: AZURE_CREDENTIALS'
     required: true
+  provider:
+    description: 'Specify the Azure your are connecting'
+    required: false
+    default: 'AzureCloud'
   enable-AzPSSession: 
     description: 'Set this value to true to enable Azure PowerShell Login in addition to Az CLI login'
     required: false

--- a/lib/main.js
+++ b/lib/main.js
@@ -39,7 +39,6 @@ function main() {
             azPath = yield io.which("az", true);
             yield executeAzCliCommand("--version");
             let provider = core.getInput('provider');
-            console.log(`provider = "${provider}"`);
             let creds = core.getInput('creds', { required: true });
             let secrets = new actions_secret_parser_1.SecretParser(creds, actions_secret_parser_1.FormatType.JSON);
             let servicePrincipalId = secrets.getSecret("$.clientId", false);

--- a/lib/main.js
+++ b/lib/main.js
@@ -38,6 +38,8 @@ function main() {
             core.exportVariable('AZUREPS_HOST_ENVIRONMENT', azurePSHostEnv);
             azPath = yield io.which("az", true);
             yield executeAzCliCommand("--version");
+            let provider = core.getInput('provider');
+            console.log(`provider = "${provider}"`);
             let creds = core.getInput('creds', { required: true });
             let secrets = new actions_secret_parser_1.SecretParser(creds, actions_secret_parser_1.FormatType.JSON);
             let servicePrincipalId = secrets.getSecret("$.clientId", false);
@@ -49,7 +51,7 @@ function main() {
                 throw new Error("Not all values are present in the creds object. Ensure clientId, clientSecret, tenantId and subscriptionId are supplied.");
             }
             // Attempting Az cli login
-            yield executeAzCliCommand(`cloud set -n AzureChinaCloud`, true);
+            yield executeAzCliCommand(`cloud set -n "${provider}"`, true);
             yield executeAzCliCommand(`login --service-principal -u "${servicePrincipalId}" -p "${servicePrincipalKey}" --tenant "${tenantId}"`, true);
             yield executeAzCliCommand(`account set --subscription "${subscriptionId}"`, true);
             isAzCLISuccess = true;

--- a/lib/main.js
+++ b/lib/main.js
@@ -49,6 +49,7 @@ function main() {
                 throw new Error("Not all values are present in the creds object. Ensure clientId, clientSecret, tenantId and subscriptionId are supplied.");
             }
             // Attempting Az cli login
+            yield executeAzCliCommand(`cloud set -n AzureChinaCloud`, true);
             yield executeAzCliCommand(`login --service-principal -u "${servicePrincipalId}" -p "${servicePrincipalKey}" --tenant "${tenantId}"`, true);
             yield executeAzCliCommand(`account set --subscription "${subscriptionId}"`, true);
             isAzCLISuccess = true;

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,6 @@ async function main() {
         await executeAzCliCommand("--version");
 
         let provider = core.getInput('provider');
-        console.log(`provider = "${provider}"`);
         let creds = core.getInput('creds', { required: true });
         let secrets = new SecretParser(creds, FormatType.JSON);
         let servicePrincipalId = secrets.getSecret("$.clientId", false);

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,8 @@ async function main() {
         azPath = await io.which("az", true);
         await executeAzCliCommand("--version");
 
+        let provider = core.getInput('provider');
+        console.log(`provider = "${provider}"`);
         let creds = core.getInput('creds', { required: true });
         let secrets = new SecretParser(creds, FormatType.JSON);
         let servicePrincipalId = secrets.getSecret("$.clientId", false);
@@ -35,7 +37,7 @@ async function main() {
             throw new Error("Not all values are present in the creds object. Ensure clientId, clientSecret, tenantId and subscriptionId are supplied.");
         }
         // Attempting Az cli login
-        await executeAzCliCommand(`cloud set -n AzureChinaCloud`, true);
+        await executeAzCliCommand(`cloud set -n "${provider}"`, true);
         await executeAzCliCommand(`login --service-principal -u "${servicePrincipalId}" -p "${servicePrincipalKey}" --tenant "${tenantId}"`, true);
         await executeAzCliCommand(`account set --subscription "${subscriptionId}"`, true);
         isAzCLISuccess = true;

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,7 @@ async function main() {
             throw new Error("Not all values are present in the creds object. Ensure clientId, clientSecret, tenantId and subscriptionId are supplied.");
         }
         // Attempting Az cli login
+        await executeAzCliCommand(`cloud set -n AzureChinaCloud`, true);
         await executeAzCliCommand(`login --service-principal -u "${servicePrincipalId}" -p "${servicePrincipalKey}" --tenant "${tenantId}"`, true);
         await executeAzCliCommand(`account set --subscription "${subscriptionId}"`, true);
         isAzCLISuccess = true;


### PR DESCRIPTION
This PR introduces a new parameter `provider` so `az cli` knows which Cloud it's talking to.

Supported values are,
- `AzureCloud`
- `AzureChinaCloud`
- `AzureUSGovernment`
- `AzureGermanCloud`
