### PR TITLE
Check Az Powershell version via file system

### DIFF
--- a/__tests__/PowerShell/Utilities/Utils.test.ts
+++ b/__tests__/PowerShell/Utilities/Utils.test.ts
@@ -20,26 +20,26 @@ describe('Testing isValidVersion', () => {
 });
 
 describe('Testing setPSModulePath', () => {
-    test('PSModulePath with azPSVersion non-empty', () => {
-        Utils.setPSModulePath(version);
+    test('PSModulePath with azPSVersion non-empty', async () => {
+        await Utils.setPSModulePath(version);
         expect(process.env.PSModulePath).toContain(version);
     });
-    test('PSModulePath with azPSVersion empty', () => {
+    test('PSModulePath with azPSVersion empty', async () => {
         const prevPSModulePath = process.env.PSModulePath;
-        Utils.setPSModulePath();
+        await Utils.setPSModulePath();
         expect(process.env.PSModulePath).not.toEqual(prevPSModulePath);
     });
 });
 
-describe('Testing getLatestModule', () => {
-    let getLatestModuleSpy;
+describe('Testing getLatestAzModule', () => {
+    let getLatestAzModuleSpy;
 
     beforeEach(() => {
-        getLatestModuleSpy = jest.spyOn(Utils, 'getLatestModule');
+        getLatestAzModuleSpy = jest.spyOn(Utils, 'getLatestAzModule');
     });
-    test('getLatestModule should pass', async () => {
-        getLatestModuleSpy.mockImplementationOnce((_moduleName: string) => Promise.resolve(version));
-        await Utils.getLatestModule(moduleName);
-        expect(getLatestModuleSpy).toHaveBeenCalled();
+    test('getLatestAzModule should pass', async () => {
+        getLatestAzModuleSpy.mockImplementationOnce((_moduleName: string) => Promise.resolve(version));
+        await Utils.getLatestAzModule(moduleName);
+        expect(getLatestAzModuleSpy).toHaveBeenCalled();
     });
 });

--- a/lib/PowerShell/Constants.js
+++ b/lib/PowerShell/Constants.js
@@ -4,7 +4,7 @@ class Constants {
 }
 exports.default = Constants;
 Constants.prefix = "az_";
-Constants.moduleName = "Az.Accounts";
+Constants.moduleName = "Az";
 Constants.versionPattern = /[0-9]\.[0-9]\.[0-9]/;
 Constants.AzureCloud = "AzureCloud";
 Constants.Subscription = "Subscription";

--- a/lib/PowerShell/ServicePrincipalLogin.js
+++ b/lib/PowerShell/ServicePrincipalLogin.js
@@ -33,10 +33,8 @@ class ServicePrincipalLogin {
     }
     initialize() {
         return __awaiter(this, void 0, void 0, function* () {
-            Utils_1.default.setPSModulePath();
-            const azLatestVersion = yield Utils_1.default.getLatestModule(Constants_1.default.moduleName);
+            const azLatestVersion = yield Utils_1.default.setPSModulePath("latest");
             core.debug(`Az Module version used: ${azLatestVersion}`);
-            Utils_1.default.setPSModulePath(`${Constants_1.default.prefix}${azLatestVersion}`);
         });
     }
     login() {

--- a/lib/PowerShell/Utilities/ScriptBuilder.js
+++ b/lib/PowerShell/Utilities/ScriptBuilder.js
@@ -41,14 +41,24 @@ class ScriptBuilder {
         core.debug(`Azure PowerShell Login Script: ${this.script}`);
         return this.script;
     }
-    getLatestModuleScript(moduleName) {
-        const command = `Get-Module -Name ${moduleName} -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1`;
+    getLatestAzModuleScript(azPathPrefix) {
+        const command = `$(if (Test-Path ${azPathPrefix}*) { \`
+                                   (Get-ChildItem ${azPathPrefix}* -Directory -Name \`
+                                       | Sort-Object -Descending \`
+                                       | Select-Object -First 1 \`
+                                   ).Substring(${Constants_1.default.prefix.length}) \`
+                                 } else {  \` 
+                                    (Get-Module -Name ${Constants_1.default.moduleName} -ListAvailable \`
+                                       | Sort-Object Version -Descending \`
+                                       | Select-Object -First 1 -ExpandProperty Version \`
+                                    ).ToString() \`
+                                 })`;
         this.script += `try {
             $ErrorActionPreference = "Stop"
             $WarningPreference = "SilentlyContinue"
             $output = @{}
             $data = ${command}
-            $output['${Constants_1.default.AzVersion}'] = $data.Version.ToString()
+            $output['${Constants_1.default.AzVersion}'] = $data
             $output['${Constants_1.default.Success}'] = "true"
         }
         catch {

--- a/lib/PowerShell/Utilities/Utils.js
+++ b/lib/PowerShell/Utilities/Utils.js
@@ -27,29 +27,42 @@ class Utils {
     /**
      * Add the folder path where Az modules are present to PSModulePath based on runner
      * @param azPSVersion
-     * If azPSVersion is empty, folder path in which all Az modules are present are set
-     * If azPSVersion is not empty, folder path of exact Az module version is set
+     * Obtain specified version, otherwise use latest version installed
+     * @returns Az Powershell version added to path
      */
-    static setPSModulePath(azPSVersion = "") {
-        let modulePath = "";
-        const runner = process.env.RUNNER_OS || os.type();
-        switch (runner.toLowerCase()) {
-            case "linux":
-                modulePath = `/usr/share/${azPSVersion}:`;
-                break;
-            case "windows":
-            case "windows_nt":
-                modulePath = `C:\\Modules\\${azPSVersion};`;
-                break;
-            case "macos":
-            case "darwin":
-                throw new Error(`OS not supported`);
-            default:
-                throw new Error(`Unknown os: ${runner.toLowerCase()}`);
-        }
-        process.env.PSModulePath = `${modulePath}${process.env.PSModulePath}`;
+    static setPSModulePath(azPSVersion = "latest") {
+        return __awaiter(this, void 0, void 0, function* () {
+            let modulePath = "";
+            let modulePathRoot = "";
+            let modulePathSeparator = "";
+            let modulePathPrefix = "";
+            const runner = process.env.RUNNER_OS || os.type();
+            switch (runner.toLowerCase()) {
+                case "linux":
+                    modulePathRoot = '/usr/share/';
+                    modulePathSeparator = ':';
+                    break;
+                case "windows":
+                case "windows_nt":
+                    modulePathRoot = 'C:\\Modules\\';
+                    modulePathSeparator = ';';
+                    break;
+                case "macos":
+                case "darwin":
+                    throw new Error(`OS not supported`);
+                default:
+                    throw new Error(`Unknown os: ${runner.toLowerCase()}`);
+            }
+            modulePathPrefix = `${modulePathRoot}${Constants_1.default.prefix}`;
+            if (azPSVersion === "latest") { // transform to latest version
+                azPSVersion = yield Utils.getLatestAzModule(modulePathPrefix);
+            }
+            modulePath = `${modulePathPrefix}${azPSVersion}${modulePathSeparator}`;
+            process.env.PSModulePath = `${modulePath}${process.env.PSModulePath}`;
+            return azPSVersion;
+        });
     }
-    static getLatestModule(moduleName) {
+    static getLatestAzModule(azPathPrefix) {
         return __awaiter(this, void 0, void 0, function* () {
             let output = "";
             const options = {
@@ -61,7 +74,7 @@ class Utils {
             };
             yield PowerShellToolRunner_1.default.init();
             yield PowerShellToolRunner_1.default.executePowerShellScriptBlock(new ScriptBuilder_1.default()
-                .getLatestModuleScript(moduleName), options);
+                .getLatestAzModuleScript(azPathPrefix), options);
             const result = JSON.parse(output.trim());
             if (!(Constants_1.default.Success in result)) {
                 throw new Error(result[Constants_1.default.Error]);

--- a/src/PowerShell/Constants.ts
+++ b/src/PowerShell/Constants.ts
@@ -1,6 +1,6 @@
 export default class Constants {
     static readonly prefix: string = "az_";
-    static readonly moduleName: string = "Az.Accounts";
+    static readonly moduleName: string = "Az";
     static readonly versionPattern = /[0-9]\.[0-9]\.[0-9]/;
 
     static readonly AzureCloud: string = "AzureCloud";

--- a/src/PowerShell/ServicePrincipalLogin.ts
+++ b/src/PowerShell/ServicePrincipalLogin.ts
@@ -22,10 +22,8 @@ export class ServicePrincipalLogin implements IAzurePowerShellSession {
     }
 
     async initialize() {
-        Utils.setPSModulePath();
-        const azLatestVersion: string = await Utils.getLatestModule(Constants.moduleName);
+        const azLatestVersion: string = await Utils.setPSModulePath("latest");
         core.debug(`Az Module version used: ${azLatestVersion}`);
-        Utils.setPSModulePath(`${Constants.prefix}${azLatestVersion}`);
     }
 
     async login() {


### PR DESCRIPTION
Since so many versions of Az Powershell are installed on the virtual environments, Get-Module can be slow. Instead, obtain available Az Powershell versions directly from the filesystem. #20