### PR TITLE
Create auto-triage-issues

### DIFF
--- a/.github/workflows/auto-triage-issues
+++ b/.github/workflows/auto-triage-issues
@@ -1,3 +1,4 @@
+name: "Auto-Labelling Issues"
 on:
   issues:
     types: [opened, edited]
@@ -5,14 +6,14 @@ on:
 jobs:
   auto_label:
     runs-on: ubuntu-latest
-    name: Automatic Github Issue Labeller
+    name: Auto-Labelling Issues
     steps:
     - name: Label Step
       uses: larrylawl/Auto-Github-Issue-Labeller@main
       with:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         REPOSITORY: ${{github.repository}}
-        DELTA: "1"
+        DELTA: "7"
         CONFIDENCE: "2"
         FEATURE: "enhancement"
         BUG: "bug"

--- a/.github/workflows/auto-triage-issues
+++ b/.github/workflows/auto-triage-issues
@@ -9,7 +9,7 @@ jobs:
     name: Auto-Labelling Issues
     steps:
     - name: Label Step
-      uses: larrylawl/Auto-Github-Issue-Labeller@main
+      uses: larrylawl/Auto-Github-Issue-Labeller@v1.0
       with:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         REPOSITORY: ${{github.repository}}
@@ -18,4 +18,4 @@ jobs:
         FEATURE: "enhancement"
         BUG: "bug"
         DOCS: "documentation"
-        VERSION: "v1.0"
+        

--- a/.github/workflows/auto-triage-issues
+++ b/.github/workflows/auto-triage-issues
@@ -1,0 +1,20 @@
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  auto_label:
+    runs-on: ubuntu-latest
+    name: Automatic Github Issue Labeller
+    steps:
+    - name: Label Step
+      uses: larrylawl/Auto-Github-Issue-Labeller@main
+      with:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        REPOSITORY: ${{github.repository}}
+        DELTA: "1"
+        CONFIDENCE: "2"
+        FEATURE: "enhancement"
+        BUG: "bug"
+        DOCS: "documentation"
+        VERSION: "v1.0"


### PR DESCRIPTION
This action automatically labels issues as bug, enhancement or doc using NLP. This action is triggered whenever an issue is created and it only labels unlabeled issues.
DELTA triggers labels issues up to DELTA days back. Its primary purpose is to label pre-existing issues on initial setup. 
CONFIDENCE  skips prediction when below confidence threshold. Any value of confidence can be picked from the interval [-10, 4]. Default value is 2. Note that -10 (or an extremely low value) essentially forces the model to make a prediction for all issues.