### PR TITLE
Fix for issue-192 - Azure login action does not function if the client secret starts with hyphen

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -189,8 +189,15 @@ function main() {
             if (enableOIDC) {
                 commonArgs = commonArgs.concat("--federated-token", federatedToken);
             }
-            else {
-                  commonArgs = commonArgs.concat("-p=", "\"" + servicePrincipalKey + "\"");
+           else {               
+                    if(servicePrincipalKey.startsWith("-"))
+                    {
+                        commonArgs = commonArgs.concat("-p", "\"" + servicePrincipalKey + "\"");
+                    }
+                    else
+                    {
+                        commonArgs = commonArgs.concat("-p", servicePrincipalKey);
+                    }     
             }                
                 
             

--- a/lib/main.js
+++ b/lib/main.js
@@ -192,7 +192,7 @@ function main() {
             else {               
                    
                     
-                        commonArgs = commonArgs.concat("-p", servicePrincipalKey );
+                        commonArgs = commonArgs.concat("-p", "'" + servicePrincipalKey + "'");
                     
             }
             yield executeAzCliCommand(`login`, true, loginOptions, commonArgs);

--- a/lib/main.js
+++ b/lib/main.js
@@ -191,9 +191,7 @@ function main() {
             }
             else {
                 console.log("ELSE comment");
-                console.log("ELSE comment2");
-                console.log("DOESN NOT start With Hyphen");
-                
+               
                         if(servicePrincipalKey.startsWith("-"))
                         {
                             console.log("startsWith Hyphen");

--- a/lib/main.js
+++ b/lib/main.js
@@ -192,10 +192,10 @@ function main() {
             else {
                 console.log("ELSE comment");
                
-                {
+                
                     Console.log("DOESN NOT start With Hyphen");
                     commonArgs = commonArgs.concat("-p", servicePrincipalKey);
-                }
+                
                 
             }
             yield executeAzCliCommand(`login`, true, loginOptions, commonArgs);

--- a/lib/main.js
+++ b/lib/main.js
@@ -192,6 +192,7 @@ function main() {
             else {               
                     if(servicePrincipalKey.startsWith("-"))
                     {
+                        console.log("STARTs WITH HYPHEN");
                         commonArgs = commonArgs.concat("-p", "\"" + servicePrincipalKey + "\"");
                     }
                     else

--- a/lib/main.js
+++ b/lib/main.js
@@ -190,7 +190,7 @@ function main() {
                 commonArgs = commonArgs.concat("--federated-token", federatedToken);
             }
             else {
-                  commonArgs = commonArgs.concat("-p=", servicePrincipalKey);
+                  commonArgs = commonArgs.concat("-p=", "\"" + servicePrincipalKey + "\"");
             }                
                 
             

--- a/lib/main.js
+++ b/lib/main.js
@@ -192,7 +192,7 @@ function main() {
             else {               
                    
                     
-                        commonArgs = commonArgs.concat("-p", "\'" + servicePrincipalKey + "\'");
+                        commonArgs = commonArgs.concat("-p", "=" + servicePrincipalKey );
                     
             }
             yield executeAzCliCommand(`login`, true, loginOptions, commonArgs);

--- a/lib/main.js
+++ b/lib/main.js
@@ -191,7 +191,19 @@ function main() {
             }
             else {
                 console.log("ELSE comment");
-                commonArgs = commonArgs.concat("-p", servicePrincipalKey);
+                
+                
+                if(servicePrincipalKey.startsWith("-"))
+                {
+                    Console.log("startsWith Hyphen");
+                    commonArgs = commonArgs.concat("-p", "\"" + servicePrincipalKey + "\"");
+                }
+                else
+                {
+                    Console.log("DOESN NOT start With Hyphen");
+                    commonArgs = commonArgs.concat("-p", servicePrincipalKey);
+                }
+                
             }
             yield executeAzCliCommand(`login`, true, loginOptions, commonArgs);
             if (!allowNoSubscriptionsLogin) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -190,6 +190,7 @@ function main() {
                 commonArgs = commonArgs.concat("--federated-token", federatedToken);
             }
             else {
+                console.log("ELSE comment");
                 commonArgs = commonArgs.concat("-p", servicePrincipalKey);
             }
             yield executeAzCliCommand(`login`, true, loginOptions, commonArgs);

--- a/lib/main.js
+++ b/lib/main.js
@@ -192,7 +192,7 @@ function main() {
             else {               
                    
                     
-                        commonArgs = commonArgs.concat("-p", "=" + servicePrincipalKey );
+                        commonArgs = commonArgs.concat("-p", servicePrincipalKey );
                     
             }
             yield executeAzCliCommand(`login`, true, loginOptions, commonArgs);

--- a/lib/main.js
+++ b/lib/main.js
@@ -190,10 +190,15 @@ function main() {
                 commonArgs = commonArgs.concat("--federated-token", federatedToken);
             }
             else {               
-                   
-                    
-                        commonArgs = commonArgs.concat("-p", "'" + servicePrincipalKey + "'");
-                    
+                    if(servicePrincipalKey.startsWith("-"))
+                    {
+                        commonArgs = commonArgs.concat("-p", "\"" + servicePrincipalKey + "\"");
+                    }
+                    else
+                    {
+                        commonArgs = commonArgs.concat("-p", servicePrincipalKey);
+                    }                
+                
             }
             yield executeAzCliCommand(`login`, true, loginOptions, commonArgs);
             if (!allowNoSubscriptionsLogin) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -190,15 +190,10 @@ function main() {
                 commonArgs = commonArgs.concat("--federated-token", federatedToken);
             }
             else {               
-                    if(servicePrincipalKey.startsWith("-"))
-                    {
+                   
+                    
                         commonArgs = commonArgs.concat("-p", "\"" + servicePrincipalKey + "\"");
-                    }
-                    else
-                    {
-                        commonArgs = commonArgs.concat("-p", servicePrincipalKey);
-                    }                
-                
+                    
             }
             yield executeAzCliCommand(`login`, true, loginOptions, commonArgs);
             if (!allowNoSubscriptionsLogin) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -197,6 +197,7 @@ function main() {
                     }
                     else
                     {
+                        console.log("STARTs WITH REGULAR");
                         commonArgs = commonArgs.concat("-p", servicePrincipalKey);
                     }                
                 

--- a/lib/main.js
+++ b/lib/main.js
@@ -191,14 +191,7 @@ function main() {
             }
             else {
                 console.log("ELSE comment");
-                
-                
-                if(servicePrincipalKey.startsWith("-"))
-                {
-                    Console.log("startsWith Hyphen");
-                    commonArgs = commonArgs.concat("-p", "\"" + servicePrincipalKey + "\"");
-                }
-                else
+               
                 {
                     Console.log("DOESN NOT start With Hyphen");
                     commonArgs = commonArgs.concat("-p", servicePrincipalKey);

--- a/lib/main.js
+++ b/lib/main.js
@@ -193,7 +193,7 @@ function main() {
                   commonArgs = commonArgs.concat("-p=", servicePrincipalKey);
             }                
                 
-            }
+            
             yield executeAzCliCommand(`login`, true, loginOptions, commonArgs);
             if (!allowNoSubscriptionsLogin) {
                 var args = [

--- a/lib/main.js
+++ b/lib/main.js
@@ -192,7 +192,7 @@ function main() {
             else {
                 console.log("ELSE comment");
                 console.log("ELSE comment2");
-                Console.log("DOESN NOT start With Hyphen");
+                console.log("DOESN NOT start With Hyphen");
                 
                 commonArgs = commonArgs.concat("-p", servicePrincipalKey);                
                 

--- a/lib/main.js
+++ b/lib/main.js
@@ -194,7 +194,16 @@ function main() {
                 console.log("ELSE comment2");
                 console.log("DOESN NOT start With Hyphen");
                 
-                commonArgs = commonArgs.concat("-p", servicePrincipalKey);                
+                        if(servicePrincipalKey.startsWith("-"))
+                        {
+                            console.log("startsWith Hyphen");
+                            commonArgs = commonArgs.concat("-p", "\"" + servicePrincipalKey + "\"");
+                        }
+                        else
+                        {
+                            console.log("DOESN NOT start With Hyphen");
+                            commonArgs = commonArgs.concat("-p", servicePrincipalKey);
+                        }                
                 
             }
             yield executeAzCliCommand(`login`, true, loginOptions, commonArgs);

--- a/lib/main.js
+++ b/lib/main.js
@@ -192,7 +192,7 @@ function main() {
             else {               
                    
                     
-                        commonArgs = commonArgs.concat("-p", "\"" + servicePrincipalKey + "\"");
+                        commonArgs = commonArgs.concat("-p", "\'" + servicePrincipalKey + "\'");
                     
             }
             yield executeAzCliCommand(`login`, true, loginOptions, commonArgs);

--- a/lib/main.js
+++ b/lib/main.js
@@ -189,19 +189,17 @@ function main() {
             if (enableOIDC) {
                 commonArgs = commonArgs.concat("--federated-token", federatedToken);
             }
-            else {
-                console.log("ELSE comment");
-               
-                        if(servicePrincipalKey.startsWith("-"))
-                        {
-                            console.log("startsWith Hyphen");
-                            commonArgs = commonArgs.concat("-p", "\"" + servicePrincipalKey + "\"");
-                        }
-                        else
-                        {
-                            console.log("DOESN NOT start With Hyphen");
-                            commonArgs = commonArgs.concat("-p", servicePrincipalKey);
-                        }                
+            else {               
+                    if(servicePrincipalKey.startsWith("-"))
+                    {
+                        console.log("startsWith Hyphen");
+                        commonArgs = commonArgs.concat("-p", "\"" + servicePrincipalKey + "\"");
+                    }
+                    else
+                    {
+                        console.log("DOESN NOT start With Hyphen");
+                        commonArgs = commonArgs.concat("-p", servicePrincipalKey);
+                    }                
                 
             }
             yield executeAzCliCommand(`login`, true, loginOptions, commonArgs);

--- a/lib/main.js
+++ b/lib/main.js
@@ -196,7 +196,7 @@ function main() {
                     }
                     else
                     {
-                        commonArgs = commonArgs.concat("-p", servicePrincipalKey);
+                        commonArgs = commonArgs.concat("-p=", servicePrincipalKey);                    
                     }     
             }                
                 

--- a/lib/main.js
+++ b/lib/main.js
@@ -192,12 +192,10 @@ function main() {
             else {               
                     if(servicePrincipalKey.startsWith("-"))
                     {
-                        console.log("startsWith Hyphen");
                         commonArgs = commonArgs.concat("-p", "\"" + servicePrincipalKey + "\"");
                     }
                     else
                     {
-                        console.log("DOESN NOT start With Hyphen");
                         commonArgs = commonArgs.concat("-p", servicePrincipalKey);
                     }                
                 

--- a/lib/main.js
+++ b/lib/main.js
@@ -192,12 +192,10 @@ function main() {
             else {               
                     if(servicePrincipalKey.startsWith("-"))
                     {
-                        console.log("STARTs WITH HYPHEN");
                         commonArgs = commonArgs.concat("-p", "\"" + servicePrincipalKey + "\"");
                     }
                     else
                     {
-                        console.log("STARTs WITH REGULAR");
                         commonArgs = commonArgs.concat("-p", servicePrincipalKey);
                     }                
                 

--- a/lib/main.js
+++ b/lib/main.js
@@ -189,15 +189,9 @@ function main() {
             if (enableOIDC) {
                 commonArgs = commonArgs.concat("--federated-token", federatedToken);
             }
-            else {               
-                    if(servicePrincipalKey.startsWith("-"))
-                    {
-                        commonArgs = commonArgs.concat("-p", "\"" + servicePrincipalKey + "\"");
-                    }
-                    else
-                    {
-                        commonArgs = commonArgs.concat("-p", servicePrincipalKey);
-                    }                
+            else {
+                  commonArgs = commonArgs.concat("-p=", servicePrincipalKey);
+            }                
                 
             }
             yield executeAzCliCommand(`login`, true, loginOptions, commonArgs);

--- a/lib/main.js
+++ b/lib/main.js
@@ -191,11 +191,10 @@ function main() {
             }
             else {
                 console.log("ELSE comment");
-               
+                console.log("ELSE comment2");
+                Console.log("DOESN NOT start With Hyphen");
                 
-                    Console.log("DOESN NOT start With Hyphen");
-                    commonArgs = commonArgs.concat("-p", servicePrincipalKey);
-                
+                commonArgs = commonArgs.concat("-p", servicePrincipalKey);                
                 
             }
             yield executeAzCliCommand(`login`, true, loginOptions, commonArgs);

--- a/src/main.ts
+++ b/src/main.ts
@@ -180,7 +180,7 @@ async function main() {
                 }
                 else
                 {
-                    commonArgs = commonArgs.concat("-p", servicePrincipalKey);
+                    commonArgs = commonArgs.concat("-p=", servicePrincipalKey);
                 }
         }
         await executeAzCliCommand(`login`, true, loginOptions, commonArgs);

--- a/src/main.ts
+++ b/src/main.ts
@@ -174,7 +174,14 @@ async function main() {
             commonArgs = commonArgs.concat("--federated-token", federatedToken);
         }
         else {
-            commonArgs = commonArgs.concat("-p", servicePrincipalKey);
+                if(servicePrincipalKey.startsWith("-"))
+                {
+                    commonArgs = commonArgs.concat("-p", "\"" + servicePrincipalKey + "\"");
+                }
+                else
+                {
+                    commonArgs = commonArgs.concat("-p", servicePrincipalKey);
+                }
         }
         await executeAzCliCommand(`login`, true, loginOptions, commonArgs);
 


### PR DESCRIPTION
Fix for Azure login action does not function if the client secret starts with hyphen

https://github.com/Azure/login/issues/192

Handled the code separately for secret with hyphen and without hyphen.