### PR TITLE
Adding az installation requirement to login error response (release PR)

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -213,10 +213,10 @@ function main() {
         }
         catch (error) {
             if (!isAzCLISuccess) {
-                core.setFailed("Az CLI Login failed. Please check the credentials. For more information refer https://aka.ms/create-secrets-for-GitHub-workflows");
+                core.setFailed("Az CLI Login failed. Please check the credentials and make sure az is installed on the runner. For more information refer https://aka.ms/create-secrets-for-GitHub-workflows");
             }
             else {
-                core.setFailed(`Azure PowerShell Login failed. Please check the credentials. For more information refer https://aka.ms/create-secrets-for-GitHub-workflows"`);
+                core.setFailed(`Azure PowerShell Login failed. Please check the credentials and make sure az is installed on the runner. For more information refer https://aka.ms/create-secrets-for-GitHub-workflows"`);
             }
         }
         finally {

--- a/src/main.ts
+++ b/src/main.ts
@@ -208,10 +208,10 @@ async function main() {
     }
     catch (error) {
         if (!isAzCLISuccess) {
-            core.setFailed("Az CLI Login failed. Please check the credentials. For more information refer https://aka.ms/create-secrets-for-GitHub-workflows");
+            core.setFailed("Az CLI Login failed. Please check the credentials and make sure az is installed on the runner. For more information refer https://aka.ms/create-secrets-for-GitHub-workflows");
         }
         else {
-            core.setFailed(`Azure PowerShell Login failed. Please check the credentials. For more information refer https://aka.ms/create-secrets-for-GitHub-workflows"`);
+            core.setFailed(`Azure PowerShell Login failed. Please check the credentials and make sure az is installed on the runner. For more information refer https://aka.ms/create-secrets-for-GitHub-workflows"`);
         }
     }
     finally {


### PR DESCRIPTION
This release PR contains:

1. A line added to the current error response to make sure `az` is installed on the runner machine.
2. Solves the issues mentioned in the comments of #104 