### PR TITLE
Update ClientSecret in the example to not call itself a GUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,10 +210,10 @@ Follow the steps to configure Azure Service Principal with a secret:
  
   {
     "clientId": "<GUID>",
-    "clientSecret": "<CLIENT_SECRET>",
+    "clientSecret": "<STRING>",
     "subscriptionId": "<GUID>",
     "tenantId": "<GUID>",
-    "resourceManagerEndpointUrl": <URL>
+    "resourceManagerEndpointUrl": "<URL>"
     (...)
   }
   

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Follow the steps to configure Azure Service Principal with a secret:
 
   {
     "clientId": "<GUID>",
-    "clientSecret": "<GUID>",
+    "clientSecret": "<CLIENT_SECRET>",
     "subscriptionId": "<GUID>",
     "tenantId": "<GUID>",
     (...)


### PR DESCRIPTION
If manually crafting or verifying a Service Principal credential JSON object, it is helpful to know that only the `clientId` is formatted as a GUID, and the `clientSecret` is just an alphanumeric string.