### PR TITLE
Add critical information if manually creating SP Credential object

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,16 +209,22 @@ Follow the steps to configure Azure Service Principal with a secret:
 
   # The command should output a JSON object similar to this:
 
+ 
   {
     "clientId": "<GUID>",
     "clientSecret": "<GUID>",
     "subscriptionId": "<GUID>",
     "tenantId": "<GUID>",
+    "resourceManagerEndpointUrl": <URL>
     (...)
   }
   
 ```
   * Now in the workflow file in your branch: `.github/workflows/workflow.yml` replace the secret in Azure login action with your secret (Refer to the example above)
+
+### Manually creating the Credentials object
+
+If you already created and assigned a Service Principal in Azure you can manually create the .json object above by finding the `clientid` and `clientsecret` on the Service Principle, and your `subscriptionId` and `tenantId` on the subscription and tenant respectively. The `resourceManagerEndpointUrl` will be `https://management.azure.com/` if you are using the public Azure cloud.
 
 ### Configure a service principal with a Federated Credential to use OIDC based authentication:
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Follow the steps to configure Azure Service Principal with a secret:
 
 ### Manually creating the Credentials object
 
-If you already created and assigned a Service Principal in Azure you can manually create the .json object above by finding the `clientid` and `clientsecret` on the Service Principle, and your `subscriptionId` and `tenantId` on the subscription and tenant respectively. The `resourceManagerEndpointUrl` will be `https://management.azure.com/` if you are using the public Azure cloud.
+If you already created and assigned a Service Principal in Azure you can manually create the .json object above by finding the `clientId` and `clientSecret` on the Service Principal, and your `subscriptionId` and `tenantId` of the subscription and tenant respectively. The `resourceManagerEndpointUrl` will be `https://management.azure.com/` if you are using the public Azure cloud.
 
 ### Configure a service principal with a Federated Credential to use OIDC based authentication:
 


### PR DESCRIPTION
If you must manually create the credential JSON (for instance, the Service Principal was created and assigned but the output credential was not saved), finding the `clientId`, `clientSecret`, `subscriptionId` and `tenantId` in azure is possible, but the `resourceManagerEndpointUrl` is also required by this Action and was much harder to track down.

By explaining it is possible and including the value for the public azure cloud (the default use case) it will help others be able to use this Action with existing Service Principal's as well.