### PR TITLE
Allow obtaining subscription id both from 'subscription-id' as well as from 'creds'

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -74,8 +74,8 @@ async function main() {
         var enableOIDC = true;
         var federatedToken = null;
 
-        // If any of the individual credentials (clent_id, tenat_id, subscription_id) is present.
-        if (servicePrincipalId || tenantId || subscriptionId) {
+        // If any of the individual credentials (clent_id, tenat_id) is present.
+        if (servicePrincipalId || tenantId) {
 
             //If few of the individual credentials (clent_id, tenat_id, subscription_id) are missing in action inputs.
             if (!(servicePrincipalId && tenantId && (subscriptionId || allowNoSubscriptionsLogin)))
@@ -88,7 +88,11 @@ async function main() {
                 servicePrincipalId = secrets.getSecret("$.clientId", true);
                 servicePrincipalKey = secrets.getSecret("$.clientSecret", true);
                 tenantId = secrets.getSecret("$.tenantId", true);
-                subscriptionId = secrets.getSecret("$.subscriptionId", true);
+
+                if(!subscriptionId) {
+                    subscriptionId = secrets.getSecret("$.subscriptionId", true);
+                }
+
                 resourceManagerEndpointUrl = secrets.getSecret("$.resourceManagerEndpointUrl", false);
             }
             else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -89,7 +89,7 @@ async function main() {
                 servicePrincipalKey = secrets.getSecret("$.clientSecret", true);
                 tenantId = secrets.getSecret("$.tenantId", true);
 
-                if(!subscriptionId) {
+                if (!subscriptionId) {
                     subscriptionId = secrets.getSecret("$.subscriptionId", true);
                 }
 


### PR DESCRIPTION
Currently, it is not possible use the action in this way:

```yml
- uses: azure/login@v1
  with:
    creds: ${{ secrets.AZURE_CREDENTIALS }}
    subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
```
where `secrets.AZURE_CREDENTIALS` = 

```json
{
    "tenantId": "f6749845-e0f4-4d98-8ea4-8910b615cd0e",
    "clientId": "c396b6d6-bf41-4ee1-81c9-0d7707db51f1",
    "clientSecret": "..."
}
```

Expected behavior: subscription id is taken from `subscription-id` input. 
Actual behavior: login fails because no subscription id is set.

This PR fixes this issue by only taking subscription id from `creds` if `subscription-id` is not set.


