### PR TITLE
Error handling for token permissions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,5 +34,5 @@ branding:
   icon: 'login.svg'
   color: 'blue'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'lib/main.js'

--- a/lib/main.js
+++ b/lib/main.js
@@ -132,17 +132,19 @@ function main() {
             // OIDC specific checks
             if (enableOIDC) {
                 console.log('Using OIDC authentication...');
-                //generating ID-token
-                let audience = core.getInput('audience', { required: false });
-                federatedToken = yield core.getIDToken(audience);
-                if (!!federatedToken) {
-                    if (environment != "azurecloud")
-                        throw new Error(`Your current environment - "${environment}" is not supported for OIDC login.`);
-                    let [issuer, subjectClaim] = yield jwtParser(federatedToken);
-                    console.log("Federated token details: \n issuer - " + issuer + " \n subject claim - " + subjectClaim);
+                try {
+                    //generating ID-token
+                    let audience = core.getInput('audience', { required: false });
+                    federatedToken = yield core.getIDToken(audience);
+                    if (!!federatedToken) {
+                        if (environment != "azurecloud")
+                            throw new Error(`Your current environment - "${environment}" is not supported for OIDC login.`);
+                        let [issuer, subjectClaim] = yield jwtParser(federatedToken);
+                        console.log("Federated token details: \n issuer - " + issuer + " \n subject claim - " + subjectClaim);
+                    }
                 }
-                else {
-                    throw new Error("Could not get ID token for authentication.");
+                catch (error) {
+                    core.error(`${error.message.split(':')[1]}. Please make sure to give write permissions to id-token in the workflow.`);
                 }
             }
             // Attempting Az cli login

--- a/src/main.ts
+++ b/src/main.ts
@@ -110,17 +110,19 @@ async function main() {
         // OIDC specific checks
         if (enableOIDC) {
             console.log('Using OIDC authentication...')
-            //generating ID-token
-            let audience = core.getInput('audience', { required: false });
-            federatedToken = await core.getIDToken(audience);
-            if (!!federatedToken) {
-                if (environment != "azurecloud")
-                    throw new Error(`Your current environment - "${environment}" is not supported for OIDC login.`);
-                let [issuer, subjectClaim] = await jwtParser(federatedToken);
-                console.log("Federated token details: \n issuer - " + issuer + " \n subject claim - " + subjectClaim);
+            try {
+                //generating ID-token
+                let audience = core.getInput('audience', { required: false });
+                federatedToken = await core.getIDToken(audience);
+                if (!!federatedToken) {
+                    if (environment != "azurecloud")
+                        throw new Error(`Your current environment - "${environment}" is not supported for OIDC login.`);
+                    let [issuer, subjectClaim] = await jwtParser(federatedToken);
+                    console.log("Federated token details: \n issuer - " + issuer + " \n subject claim - " + subjectClaim);
+                }
             }
-            else {
-                throw new Error("Could not get ID token for authentication.");
+            catch (error) {
+                core.error(`${error.message.split(':')[1]}. Please make sure to give write permissions to id-token in the workflow.`);
             }
         }
 


### PR DESCRIPTION
PR against master branch - #234 
In this release PR - 
1. Throwing error to set `id-token` permissions for OIDC in case not set.
<img width="1281" alt="Screenshot 2022-06-17 at 3 41 57 PM" src="https://user-images.githubusercontent.com/26038662/174278246-dab3cda6-9e22-4550-8f06-04b7ca5c8d47.png">
2. Upgrading node version to address  #225 
