### PR TITLE
[BUG FIX] Version pattern quickfix releases

### DIFF
--- a/lib/PowerShell/Constants.js
+++ b/lib/PowerShell/Constants.js
@@ -5,7 +5,7 @@ class Constants {
 exports.default = Constants;
 Constants.prefix = "az_";
 Constants.moduleName = "Az.Accounts";
-Constants.versionPattern = /[0-9]\.[0-9]\.[0-9]/;
+Constants.versionPattern = /[0-9]+\.[0-9]+\.[0-9]+/;
 Constants.AzureCloud = "AzureCloud";
 Constants.Subscription = "Subscription";
 Constants.ServicePrincipal = "ServicePrincipal";

--- a/src/PowerShell/Constants.ts
+++ b/src/PowerShell/Constants.ts
@@ -1,7 +1,7 @@
 export default class Constants {
     static readonly prefix: string = "az_";
     static readonly moduleName: string = "Az.Accounts";
-    static readonly versionPattern = /[0-9]\.[0-9]\.[0-9]/;
+    static readonly versionPattern = /[0-9]+\.[0-9]+\.[0-9]+/;
 
     static readonly AzureCloud: string = "AzureCloud";
     static readonly Subscription: string = "Subscription";


### PR DESCRIPTION
The [version_pattern_regex](https://github.com/Azure/login/blob/master/src/PowerShell/Constants.ts#L4) in the action, it was accepting only single-digit major, minor, and patch version numbers. Since the new release was 2.10, the validation is failing and failing the action. So fixing that regex is working now.
