### PR TITLE
Close the issue with label `needs-author-feedback` for 20 days without activity

### DIFF
--- a/.github/workflows/defaultLabels.yml
+++ b/.github/workflows/defaultLabels.yml
@@ -34,3 +34,14 @@ jobs:
           days-before-stale: 14
           days-before-close: -1
           operations-per-run: 100
+
+      - uses: actions/stale@v3
+        name: Closing issue with no feedback for 7 days
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: '""'
+          close-issue-message: 'This issue has been labeled as `needs-author-feedback` for 7 days without activity and is being closed. If you believe this issue still requires attention, please reopen and provide the requested information.'
+          days-before-stale: 7
+          days-before-close: 0
+          stale-issue-label: 'needs-author-feedback'
+          operations-per-run: 100

--- a/.github/workflows/defaultLabels.yml
+++ b/.github/workflows/defaultLabels.yml
@@ -39,7 +39,7 @@ jobs:
         name: Close issue with no feedback for 20 days
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          close-issue-message: 'This issue has been labeled as `needs-author-feedback` for 20 days without activity and is being closed. If you believe this issue still requires attention, please reopen and provide the requested information.'
+          close-issue-message: 'This issue has been labeled as `needs-author-feedback` for 20 days with no activity. We will close it for now. If you require additional assistance, please feel free to reopen it with the required information.'
           days-before-stale: -1
           days-before-close: 20
           stale-issue-label: 'needs-author-feedback'

--- a/.github/workflows/defaultLabels.yml
+++ b/.github/workflows/defaultLabels.yml
@@ -41,7 +41,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: '""'
           close-issue-message: 'This issue has been labeled as `needs-author-feedback` for 7 days without activity and is being closed. If you believe this issue still requires attention, please reopen and provide the requested information.'
-          days-before-stale: 7
+          days-before-stale: 20
           days-before-close: 0
           stale-issue-label: 'needs-author-feedback'
           operations-per-run: 100

--- a/.github/workflows/defaultLabels.yml
+++ b/.github/workflows/defaultLabels.yml
@@ -35,13 +35,14 @@ jobs:
           days-before-close: -1
           operations-per-run: 100
 
-      - uses: actions/stale@v3
-        name: Closing issue with no feedback for 7 days
+      - uses: actions/stale@v8
+        name: Close issue with no feedback for 20 days
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: '""'
-          close-issue-message: 'This issue has been labeled as `needs-author-feedback` for 7 days without activity and is being closed. If you believe this issue still requires attention, please reopen and provide the requested information.'
-          days-before-stale: 20
-          days-before-close: 0
+          close-issue-message: 'This issue has been labeled as `needs-author-feedback` for 20 days without activity and is being closed. If you believe this issue still requires attention, please reopen and provide the requested information.'
+          days-before-stale: -1
+          days-before-close: 20
           stale-issue-label: 'needs-author-feedback'
+          only-issue-labels: 'needs-author-feedback'
+          close-issue-reason: 'completed'
           operations-per-run: 100


### PR DESCRIPTION
Automatically check whether the issue has been labeled `needs-author-feedback` for 20 days without activity. If yes, then close the issue with a comment. If the author has updated the issue, then remove the `needs-author-feedback` label.

Set `days-before-stale` as `-1`, so that it will not reset any other stale label.
Set `needs-author-feedback` as `stale-issue-label`, so that if the issue has any update, it will remove the `needs-author-feedback` label. This ensures that only issues without any update will be closed. 
Set `only-issue-labels` as `needs-author-feedback`, so that only issues with `needs-author-feedback` label are searched.
