### PR TITLE
Support Managed Identity login for self-hosted runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Note:
 ## Sample workflow that uses Azure login action to run az cli
 
 ```yaml
-
 # File: .github/workflows/workflow.yml
 
 on: [push]
@@ -54,7 +53,6 @@ jobs:
 ## Sample workflow that uses Azure login action to run Azure PowerShell
 
 ```yaml
-
 # File: .github/workflows/workflow.yml
 
 on: [push]
@@ -93,18 +91,20 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Az CLI login'
+      - name: Az CLI login
         uses: azure/login@v1
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
   
-      - name: 'Run az commands'
-        run: |
-          az account show
-          az group list
-          pwd 
+      - name: Azure CLI script
+        uses: azure/CLI@v1
+        with:
+          azcliversion: latest
+          inlineScript: |
+            az account show
+            az group list
 ```
 
 Users can also specify `audience` field for access-token in the input parameters of the action. If not specified, it is defaulted to `api://AzureADTokenExchange`. This action supports login az powershell as well for both Windows and Linux runners by setting an input parameter `enable-AzPSSession: true`. Below is the sample workflow for the same using the Windows runner. Please note that powershell login is not supported in macOS runners.
@@ -147,6 +147,8 @@ Refer to the [Azure PowerShell](https://github.com/azure/powershell) GitHub Acti
 ## Sample to connect to Azure US Government cloud
 
 ```yaml
+# File: .github/workflows/workflow.yml
+
     - name: Login to Azure US Gov Cloud with CLI
       uses: azure/login@v1
       with:
@@ -166,7 +168,6 @@ Refer to the [Azure PowerShell](https://github.com/azure/powershell) GitHub Acti
 ## Sample Azure Login workflow that uses Azure login action to run az cli on Azure Stack Hub
 
 ```yaml
-
 # File: .github/workflows/workflow.yml
 
 on: [push]
@@ -247,23 +248,33 @@ Please refer to Microsoft's documentation at ["Configure a federated identity cr
 You can add federated credentials in the Azure portal or with the Microsoft Graph REST API.
 
 ## Using Azure Managed Identities with self-hosted runners:
-If you want to use managed identities (system- or user-assigned) to sign in, a self-hosted Github runner is required to be installed on an Azure VM ["with a managed identity configured"](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/qs-configure-cli-windows-vm). To use managed identity, please set the `enable-managed-identity` flag to `true`. This will use a system-assigned managed identity unless the resource ID of a user-assigned managed identity: `user-managed-identity-resource-id` is supplied.
+If you want to use managed identities (system- or user-assigned) to sign in, a self-hosted Github runner is required to be installed on an Azure VM [with a managed identity configured](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/qs-configure-cli-windows-vm). To use managed identity, please set the `enable-managed-identity` flag to `true`. This will use a system-assigned managed identity unless the resource ID of a user-assigned managed identity: `user-managed-identity-resource-id` is supplied.
 To get the resource ID of a user-assigned managed identity:
-- in the portal, `Resource ID` is available in the Properties blade of the user-assigned managed identity resource.
-- in az PowerShell, use this command: `$(Get-AzUserAssignedIdentity -Name name-of-the-managed-identity-resource -ResourceGroupName name-of-the-resource-group).Id`{:.pwsh}
-- in az cli, use this command: `az identity list -g resource-group-name`{:.bash}
+- In the portal, it is available in the `Properties` blade of the user-assigned managed identity resource.
+- In az PowerShell, use the command: 
+```pwsh
+$(Get-AzUserAssignedIdentity -Name name-of-the-managed-identity-resource -ResourceGroupName name-of-the-resource-group).Id
+```
+- In az cli, use the command: 
+```bash
+az vm identity show --resource-group <resource_group_name> --name <vm_name> --query userAssignedIdentities
+
+```
 The resource ID usually follows a format similar to this:
 
-`/subscriptions/<subscription-id>/resourcegroups/<resource-group-name>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<your-user-assigned-managed-identity-name>`
+```bash
+/subscriptions/<subscription-id>/resourcegroups/<resource-group-name>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<your-user-assigned-managed-identity-name> 
+```
 
 For security concern, we recommend you to store it as a secret in the GitHub repository. 
 
-Subscription ID is not required when using Managed Identity. However some user-assigned managed identities may have permission in more than one subscription, please provide the subscription ID in `subscription-id` via a secret to explictly use a specific subscription. If you decide not to specify the subscription, please don't forget to set the optional parameter `allow-no-subscriptions` to `true`.
+Subscription ID is not required when using system-assigned managed identity. However, some user-assigned managed identities may have permission in more than one subscription, please provide the `subscription-id` to explictly use a specific subscription. If you decide not to specify the subscription, please don't forget to set the optional parameter `allow-no-subscriptions` to `true`.
 
 ## Sample workflow that uses Azure login action with system-assigned managed identity
 
 ```yaml
 # File: .github/workflows/workflow.yml
+
 on: [push]
 
 name: Azure System-assigned Managed Identity sample
@@ -278,11 +289,9 @@ jobs:
       with:
         enable-managed-identity: true
 
-    - name: Azure CLI script
-      uses: azure/CLI@v1
-      with:
-        inlineScript: |
-          az account show
+    - name: Show az account
+      run: |
+        az account show
 
 ```
 
@@ -290,6 +299,7 @@ jobs:
 
 ```yaml
 # File: .github/workflows/workflow.yml
+
 on: [push]
 
 name: Azure User-assigned Managed Identity sample
@@ -306,11 +316,9 @@ jobs:
         user-managed-identity-resource-id: ${{ secrets.AZURE_USER_MANAGED_IDENTITY }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-    - name: Azure CLI script
-      uses: azure/CLI@v1
-      with:
-        inlineScript: |
-          az account show
+    - name: Show az account
+      run: |
+        az account show
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -247,26 +247,31 @@ Please refer to Microsoft's documentation at ["Configure a federated identity cr
 
 You can add federated credentials in the Azure portal or with the Microsoft Graph REST API.
 
-## Using Azure Managed Identities with self-hosted runners:
+## Using Azure Managed Identities with self-hosted runners
+
 If you want to use managed identities (system- or user-assigned) to sign in, a self-hosted Github runner is required to be installed on an Azure VM [with a managed identity configured](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/qs-configure-cli-windows-vm). To use managed identity, please set the `enable-managed-identity` flag to `true`. This will use a system-assigned managed identity unless the resource ID of a user-assigned managed identity: `user-managed-identity-resource-id` is supplied.
 To get the resource ID of a user-assigned managed identity:
+
 - In the portal, it is available in the `Properties` blade of the user-assigned managed identity resource.
-- In az PowerShell, use the command: 
+- In az PowerShell, use the command:
+
 ```pwsh
 $(Get-AzUserAssignedIdentity -Name name-of-the-managed-identity-resource -ResourceGroupName name-of-the-resource-group).Id
 ```
-- In az cli, use the command: 
+
+- In az cli, use the command:
+
 ```bash
 az vm identity show --resource-group <resource_group_name> --name <vm_name> --query userAssignedIdentities
-
 ```
+
 The resource ID usually follows a format similar to this:
 
 ```bash
 /subscriptions/<subscription-id>/resourcegroups/<resource-group-name>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<your-user-assigned-managed-identity-name> 
 ```
 
-For security concern, we recommend you to store it as a secret in the GitHub repository. 
+For security concern, we recommend you to store it as a secret in the GitHub repository.
 
 Subscription ID is not required when using system-assigned managed identity. However, some user-assigned managed identities may have permission in more than one subscription, please provide the `subscription-id` to explictly use a specific subscription. If you decide not to specify the subscription, please don't forget to set the optional parameter `allow-no-subscriptions` to `true`.
 

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 # Login to Azure subscription
 name: 'Azure Login'
-description: 'Authenticate to Azure using OIDC and run your Az CLI or Az PowerShell based Actions or scripts. github.com/Azure/Actions'
-inputs: 
+description: 'Authenticate to Azure using OIDC and run your Az CLI or Az PowerShell based actions or scripts. github.com/Azure/Actions'
+inputs:
   creds:
     description: 'Paste output of `az ad sp create-for-rbac` as value of secret variable: AZURE_CREDENTIALS'
     required: false
@@ -14,8 +14,17 @@ inputs:
   subscription-id:
     description: 'Azure subscriptionId'
     required: false
+  enable-managed-identity: 
+    description: 'Set this value to true to enable Managed Identity for your action. Requires a self-hosted Github runner on an Azure VM with Managed Identity enabled.'
+    required: false
+    default: false
+  user-managed-identity-resource-id:
+    description: >-
+      'Set this value to the Resource ID of your user managed identity. If using a system managed identity, leave this empty.
+      This setting has no effect if enable-managed-identity is false.'
+    required: false
   enable-AzPSSession: 
-    description: 'Set this value to true to enable Azure PowerShell Login in addition to Az CLI login'
+    description: 'Set this value to true to enable Azure PowerShell Login in addition to Az CLI login'
     required: false
     default: false
   environment:
@@ -23,7 +32,7 @@ inputs:
     required: false
     default: azurecloud
   allow-no-subscriptions:
-    description: 'Set this value to true to enable support for accessing tenants without subscriptions'
+    description: 'Set this value to true to enable support for accessing tenants without subscriptions'
     required: false
     default: false
   audience:

--- a/lib/PowerShell/ServicePrincipalLogin.js
+++ b/lib/PowerShell/ServicePrincipalLogin.js
@@ -1,7 +1,11 @@
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -14,7 +18,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };

--- a/lib/PowerShell/Utilities/PowerShellToolRunner.js
+++ b/lib/PowerShell/Utilities/PowerShellToolRunner.js
@@ -1,7 +1,11 @@
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -14,7 +18,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };

--- a/lib/PowerShell/Utilities/ScriptBuilder.js
+++ b/lib/PowerShell/Utilities/ScriptBuilder.js
@@ -1,7 +1,11 @@
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -14,7 +18,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };

--- a/lib/PowerShell/Utilities/Utils.js
+++ b/lib/PowerShell/Utilities/Utils.js
@@ -1,7 +1,11 @@
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -14,7 +18,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };

--- a/lib/main.js
+++ b/lib/main.js
@@ -104,14 +104,26 @@ function main() {
             var federatedToken = null;
             const useManagedIdentity = core.getInput('enable-managed-identity').toLowerCase() === "true";
             const userManagedIdentityResourceId = core.getInput('user-managed-identity-resource-id', { required: false });
-            // If any of the individual credentials (clent_id, tenat_id, subscription_id) is present.
-            if (servicePrincipalId || tenantId || subscriptionId) {
-                //If few of the individual credentials (clent_id, tenat_id, subscription_id) are missing in action inputs.
-                if (!(servicePrincipalId && tenantId && (subscriptionId || allowNoSubscriptionsLogin)))
-                    throw new Error("Few credentials are missing. ClientId, tenantId are mandatory. SubscriptionId is also mandatory if allow-no-subscriptions is not set.");
+            // Check if managed identity is enabled first
+            if (useManagedIdentity) {
+                if (userManagedIdentityResourceId) {
+                    core.debug('using user-assigned managed identity...');
+                    if (!subscriptionId && !allowNoSubscriptionsLogin) {
+                        throw new Error("SubscriptionId is mandatory for user-assigned managed identity login if allow-no-subscriptions is not set.");
+                    }
+                }
+                else {
+                    core.debug('using system-assigned managed identity...');
+                }
             }
             else {
-                if (creds) {
+                // If any of the individual credentials (client_id, tenant_id, subscriptionId) is present, OIDC login is used by default.
+                if (servicePrincipalId || tenantId || subscriptionId) {
+                    //If few of the individual credentials (client_id, tenant_id, subscriptionId) are missing in action inputs.
+                    if (!(servicePrincipalId && tenantId && (subscriptionId || allowNoSubscriptionsLogin)))
+                        throw new Error("Few credentials are missing. ClientId, tenantId are mandatory. SubscriptionId is also mandatory if allow-no-subscriptions is not set.");
+                }
+                else if (creds) {
                     core.debug('using creds JSON...');
                     enableOIDC = false;
                     servicePrincipalId = secrets.getSecret("$.clientId", true);
@@ -119,48 +131,38 @@ function main() {
                     tenantId = secrets.getSecret("$.tenantId", true);
                     subscriptionId = secrets.getSecret("$.subscriptionId", true);
                     resourceManagerEndpointUrl = secrets.getSecret("$.resourceManagerEndpointUrl", false);
-                }
-                else if (useManagedIdentity) {
-                    if (userManagedIdentityResourceId) {
-                        core.debug('using user-assigned managed identity...');
+                    //servicePrincipalKey is only required in non-oidc scenario.
+                    if (!servicePrincipalId || !tenantId || !servicePrincipalKey) {
+                        throw new Error("Not all values are present in the credentials. Ensure clientId, clientSecret and tenantId are supplied.");
                     }
-                    else {
-                        core.debug('using system-assigned managed identity...');
+                    if (!subscriptionId && !allowNoSubscriptionsLogin) {
+                        throw new Error("Not all values are present in the credentials. Ensure subscriptionId is supplied.");
                     }
                 }
                 else {
-                    throw new Error("Credentials are not passed for Login action and managed identity is not enabled.");
+                    throw new Error("Credentials are not passed for Login action.");
                 }
             }
-            if (!useManagedIdentity) {
-                //generic checks 
-                //servicePrincipalKey is only required in non-oidc scenario.
-                if (!servicePrincipalId || !tenantId || !(servicePrincipalKey || enableOIDC)) {
-                    throw new Error("Not all values are present in the credentials. Ensure clientId, clientSecret and tenantId are supplied.");
-                }
-                if (!subscriptionId && !allowNoSubscriptionsLogin) {
-                    throw new Error("Not all values are present in the credentials. Ensure subscriptionId is supplied.");
-                }
-                if (!azureSupportedCloudName.has(environment)) {
-                    throw new Error("Unsupported value for environment is passed.The list of supported values for environment are ‘azureusgovernment', ‘azurechinacloud’, ‘azuregermancloud’, ‘azurecloud’ or ’azurestack’");
-                }
-                // OIDC specific checks
-                if (enableOIDC) {
-                    console.log('Using OIDC authentication...');
-                    try {
-                        //generating ID-token
-                        let audience = core.getInput('audience', { required: false });
-                        federatedToken = yield core.getIDToken(audience);
-                        if (!!federatedToken) {
-                            if (environment != "azurecloud")
-                                throw new Error(`Your current environment - "${environment}" is not supported for OIDC login.`);
-                            let [issuer, subjectClaim] = yield jwtParser(federatedToken);
-                            console.log("Federated token details: \n issuer - " + issuer + " \n subject claim - " + subjectClaim);
-                        }
+            // Check for the environment
+            if (!azureSupportedCloudName.has(environment)) {
+                throw new Error("Unsupported value for environment is passed.The list of supported values for environment are ‘azureusgovernment', ‘azurechinacloud’, ‘azuregermancloud’, ‘azurecloud’ or ’azurestack’");
+            }
+            // OIDC specific checks
+            if (enableOIDC) {
+                console.log('Using OIDC authentication...');
+                try {
+                    //generating ID-token
+                    let audience = core.getInput('audience', { required: false });
+                    federatedToken = yield core.getIDToken(audience);
+                    if (!!federatedToken) {
+                        if (environment != "azurecloud")
+                            throw new Error(`Your current environment - "${environment}" is not supported for OIDC login.`);
+                        let [issuer, subjectClaim] = yield jwtParser(federatedToken);
+                        console.log("Federated token details: \n issuer - " + issuer + " \n subject claim - " + subjectClaim);
                     }
-                    catch (error) {
-                        core.error(`${error.message.split(':')[1]}. Please make sure to give write permissions to id-token in the workflow.`);
-                    }
+                }
+                catch (error) {
+                    core.error(`${error.message.split(':')[1]}. Please make sure to give write permissions to id-token in the workflow.`);
                 }
             }
             // Attempting Az cli login
@@ -195,14 +197,15 @@ function main() {
             yield executeAzCliCommand(`cloud set -n "${environment}"`, false);
             console.log(`Done setting cloud: "${environment}"`);
             // Attempting Az cli login
+            var commonArgs = [""];
             if (useManagedIdentity) {
-                var commonArgs = ["--identity"];
+                commonArgs = ["--identity"];
                 if (userManagedIdentityResourceId) {
                     commonArgs = commonArgs.concat("-u", userManagedIdentityResourceId);
                 }
             }
             else {
-                var commonArgs = ["--service-principal",
+                commonArgs = ["--service-principal",
                     "-u", servicePrincipalId,
                     "--tenant", tenantId
                 ];
@@ -220,13 +223,13 @@ function main() {
             yield executeAzCliCommand(`login`, true, loginOptions, commonArgs);
             if (!allowNoSubscriptionsLogin) {
                 if (!(useManagedIdentity && !userManagedIdentityResourceId)) {
-                    //pass when using a system-assigned managed identity
                     var args = [
                         "--subscription",
                         subscriptionId
                     ];
                     yield executeAzCliCommand(`account set`, true, loginOptions, args);
                 }
+                //pass when using a system-assigned managed identity
             }
             isAzCLISuccess = true;
             if (enableAzPSSession) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -106,6 +106,7 @@ function main() {
             const userManagedIdentityResourceId = core.getInput('user-managed-identity-resource-id', { required: false });
             // Check if managed identity is enabled first
             if (useManagedIdentity) {
+                enableOIDC = false;
                 if (userManagedIdentityResourceId) {
                     core.debug('using user-assigned managed identity...');
                     if (!subscriptionId && !allowNoSubscriptionsLogin) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,7 +1,11 @@
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -14,7 +18,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
@@ -98,6 +102,8 @@ function main() {
             var resourceManagerEndpointUrl = "https://management.azure.com/";
             var enableOIDC = true;
             var federatedToken = null;
+            const useManagedIdentity = core.getInput('enable-managed-identity').toLowerCase() === "true";
+            const userManagedIdentityResourceId = core.getInput('user-managed-identity-resource-id', { required: false });
             // If any of the individual credentials (clent_id, tenat_id, subscription_id) is present.
             if (servicePrincipalId || tenantId || subscriptionId) {
                 //If few of the individual credentials (clent_id, tenat_id, subscription_id) are missing in action inputs.
@@ -114,37 +120,47 @@ function main() {
                     subscriptionId = secrets.getSecret("$.subscriptionId", true);
                     resourceManagerEndpointUrl = secrets.getSecret("$.resourceManagerEndpointUrl", false);
                 }
-                else {
-                    throw new Error("Credentials are not passed for Login action.");
-                }
-            }
-            //generic checks 
-            //servicePrincipalKey is only required in non-oidc scenario.
-            if (!servicePrincipalId || !tenantId || !(servicePrincipalKey || enableOIDC)) {
-                throw new Error("Not all values are present in the credentials. Ensure clientId, clientSecret and tenantId are supplied.");
-            }
-            if (!subscriptionId && !allowNoSubscriptionsLogin) {
-                throw new Error("Not all values are present in the credentials. Ensure subscriptionId is supplied.");
-            }
-            if (!azureSupportedCloudName.has(environment)) {
-                throw new Error("Unsupported value for environment is passed.The list of supported values for environment are ‘azureusgovernment', ‘azurechinacloud’, ‘azuregermancloud’, ‘azurecloud’ or ’azurestack’");
-            }
-            // OIDC specific checks
-            if (enableOIDC) {
-                console.log('Using OIDC authentication...');
-                try {
-                    //generating ID-token
-                    let audience = core.getInput('audience', { required: false });
-                    federatedToken = yield core.getIDToken(audience);
-                    if (!!federatedToken) {
-                        if (environment != "azurecloud")
-                            throw new Error(`Your current environment - "${environment}" is not supported for OIDC login.`);
-                        let [issuer, subjectClaim] = yield jwtParser(federatedToken);
-                        console.log("Federated token details: \n issuer - " + issuer + " \n subject claim - " + subjectClaim);
+                else if (useManagedIdentity) {
+                    if (userManagedIdentityResourceId) {
+                        core.debug('using user-assigned managed identity...');
+                    }
+                    else {
+                        core.debug('using system-assigned managed identity...');
                     }
                 }
-                catch (error) {
-                    core.error(`${error.message.split(':')[1]}. Please make sure to give write permissions to id-token in the workflow.`);
+                else {
+                    throw new Error("Credentials are not passed for Login action and managed identity is not enabled.");
+                }
+            }
+            if (!useManagedIdentity) {
+                //generic checks 
+                //servicePrincipalKey is only required in non-oidc scenario.
+                if (!servicePrincipalId || !tenantId || !(servicePrincipalKey || enableOIDC)) {
+                    throw new Error("Not all values are present in the credentials. Ensure clientId, clientSecret and tenantId are supplied.");
+                }
+                if (!subscriptionId && !allowNoSubscriptionsLogin) {
+                    throw new Error("Not all values are present in the credentials. Ensure subscriptionId is supplied.");
+                }
+                if (!azureSupportedCloudName.has(environment)) {
+                    throw new Error("Unsupported value for environment is passed.The list of supported values for environment are ‘azureusgovernment', ‘azurechinacloud’, ‘azuregermancloud’, ‘azurecloud’ or ’azurestack’");
+                }
+                // OIDC specific checks
+                if (enableOIDC) {
+                    console.log('Using OIDC authentication...');
+                    try {
+                        //generating ID-token
+                        let audience = core.getInput('audience', { required: false });
+                        federatedToken = yield core.getIDToken(audience);
+                        if (!!federatedToken) {
+                            if (environment != "azurecloud")
+                                throw new Error(`Your current environment - "${environment}" is not supported for OIDC login.`);
+                            let [issuer, subjectClaim] = yield jwtParser(federatedToken);
+                            console.log("Federated token details: \n issuer - " + issuer + " \n subject claim - " + subjectClaim);
+                        }
+                    }
+                    catch (error) {
+                        core.error(`${error.message.split(':')[1]}. Please make sure to give write permissions to id-token in the workflow.`);
+                    }
                 }
             }
             // Attempting Az cli login
@@ -179,27 +195,38 @@ function main() {
             yield executeAzCliCommand(`cloud set -n "${environment}"`, false);
             console.log(`Done setting cloud: "${environment}"`);
             // Attempting Az cli login
-            var commonArgs = ["--service-principal",
-                "-u", servicePrincipalId,
-                "--tenant", tenantId
-            ];
-            if (allowNoSubscriptionsLogin) {
-                commonArgs = commonArgs.concat("--allow-no-subscriptions");
-            }
-            if (enableOIDC) {
-                commonArgs = commonArgs.concat("--federated-token", federatedToken);
+            if (useManagedIdentity) {
+                var commonArgs = ["--identity"];
+                if (userManagedIdentityResourceId) {
+                    commonArgs = commonArgs.concat("-u", userManagedIdentityResourceId);
+                }
             }
             else {
-                console.log("Note: Azure/login action also supports OIDC login mechanism. Refer https://github.com/azure/login#configure-a-service-principal-with-a-federated-credential-to-use-oidc-based-authentication for more details.");
-                commonArgs = commonArgs.concat("-p", servicePrincipalKey);
+                var commonArgs = ["--service-principal",
+                    "-u", servicePrincipalId,
+                    "--tenant", tenantId
+                ];
+                if (allowNoSubscriptionsLogin) {
+                    commonArgs = commonArgs.concat("--allow-no-subscriptions");
+                }
+                if (enableOIDC) {
+                    commonArgs = commonArgs.concat("--federated-token", federatedToken);
+                }
+                else {
+                    console.log("Note: Azure/login action also supports OIDC login mechanism. Refer https://github.com/azure/login#configure-a-service-principal-with-a-federated-credential-to-use-oidc-based-authentication for more details.");
+                    commonArgs = commonArgs.concat(`--password=${servicePrincipalKey}`);
+                }
             }
             yield executeAzCliCommand(`login`, true, loginOptions, commonArgs);
             if (!allowNoSubscriptionsLogin) {
-                var args = [
-                    "--subscription",
-                    subscriptionId
-                ];
-                yield executeAzCliCommand(`account set`, true, loginOptions, args);
+                if (!(useManagedIdentity && !userManagedIdentityResourceId)) {
+                    //pass when using a system-assigned managed identity
+                    var args = [
+                        "--subscription",
+                        subscriptionId
+                    ];
+                    yield executeAzCliCommand(`account set`, true, loginOptions, args);
+                }
             }
             isAzCLISuccess = true;
             if (enableAzPSSession) {
@@ -217,7 +244,7 @@ function main() {
                 core.setFailed(`Az CLI Login failed with ${error}. Please check the credentials and make sure az is installed on the runner. For more information refer https://aka.ms/create-secrets-for-GitHub-workflows`);
             }
             else {
-                core.setFailed(`Azure PowerShell Login failed with ${error}. Please check the credentials and make sure az is installed on the runner. For more information refer https://aka.ms/create-secrets-for-GitHub-workflows"`);
+                core.setFailed(`Azure PowerShell Login failed with ${error}. Please check the credentials and make sure az is installed on the runner. For more information refer https://aka.ms/create-secrets-for-GitHub-workflows`);
             }
         }
         finally {

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,6 +78,7 @@ async function main() {
 
         // Check if managed identity is enabled first
         if (useManagedIdentity){
+            enableOIDC = false;
             if(userManagedIdentityResourceId){
                 core.debug('using user-assigned managed identity...');
                 if (!subscriptionId && !allowNoSubscriptionsLogin) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,15 +76,26 @@ async function main() {
         const useManagedIdentity = core.getInput('enable-managed-identity').toLowerCase() === "true";
         const userManagedIdentityResourceId = core.getInput('user-managed-identity-resource-id', { required: false });
 
-        // If any of the individual credentials (clent_id, tenat_id, subscription_id) is present.
-        if (servicePrincipalId || tenantId || subscriptionId) {
-
-            //If few of the individual credentials (clent_id, tenat_id, subscription_id) are missing in action inputs.
-            if (!(servicePrincipalId && tenantId && (subscriptionId || allowNoSubscriptionsLogin)))
-                throw new Error("Few credentials are missing. ClientId, tenantId are mandatory. SubscriptionId is also mandatory if allow-no-subscriptions is not set.");
+        // Check if managed identity is enabled first
+        if (useManagedIdentity){
+            if(userManagedIdentityResourceId){
+                core.debug('using user-assigned managed identity...');
+                if (!subscriptionId && !allowNoSubscriptionsLogin) {
+                    throw new Error("SubscriptionId is mandatory for user-assigned managed identity login if allow-no-subscriptions is not set.");
+                }
+            }
+            else{
+                core.debug('using system-assigned managed identity...');
+            }
         }
-        else {
-            if (creds) {
+        else{
+            // If any of the individual credentials (client_id, tenant_id, subscriptionId) is present, OIDC login is used by default.
+            if (servicePrincipalId || tenantId || subscriptionId) {
+                //If few of the individual credentials (client_id, tenant_id, subscriptionId) are missing in action inputs.
+                if (!(servicePrincipalId && tenantId && (subscriptionId || allowNoSubscriptionsLogin)))
+                    throw new Error("Few credentials are missing. ClientId, tenantId are mandatory. SubscriptionId is also mandatory if allow-no-subscriptions is not set.");
+            }
+            else if (creds) {
                 core.debug('using creds JSON...');
                 enableOIDC = false;
                 servicePrincipalId = secrets.getSecret("$.clientId", true);
@@ -92,50 +103,40 @@ async function main() {
                 tenantId = secrets.getSecret("$.tenantId", true);
                 subscriptionId = secrets.getSecret("$.subscriptionId", true);
                 resourceManagerEndpointUrl = secrets.getSecret("$.resourceManagerEndpointUrl", false);
-            }
-            else if(useManagedIdentity){
-                if(userManagedIdentityResourceId){
-                    core.debug('using user-assigned managed identity...');
+                //servicePrincipalKey is only required in non-oidc scenario.
+                if (!servicePrincipalId || !tenantId || !servicePrincipalKey) {
+                    throw new Error("Not all values are present in the credentials. Ensure clientId, clientSecret and tenantId are supplied.");
                 }
-                else{
-                    core.debug('using system-assigned managed identity...');
+                if (!subscriptionId && !allowNoSubscriptionsLogin) {
+                    throw new Error("Not all values are present in the credentials. Ensure subscriptionId is supplied.");
                 }
-            }
+            }  
             else {
-                throw new Error("Credentials are not passed for Login action and managed identity is not enabled.");
+                throw new Error("Credentials are not passed for Login action.");
             }
         }
+            
+        // Check for the environment
+        if (!azureSupportedCloudName.has(environment)) {
+            throw new Error("Unsupported value for environment is passed.The list of supported values for environment are ‘azureusgovernment', ‘azurechinacloud’, ‘azuregermancloud’, ‘azurecloud’ or ’azurestack’");
+        }
 
-        if(!useManagedIdentity){
-            //generic checks 
-            //servicePrincipalKey is only required in non-oidc scenario.
-            if (!servicePrincipalId || !tenantId || !(servicePrincipalKey || enableOIDC)) {
-                throw new Error("Not all values are present in the credentials. Ensure clientId, clientSecret and tenantId are supplied.");
-            }
-            if (!subscriptionId && !allowNoSubscriptionsLogin) {
-                throw new Error("Not all values are present in the credentials. Ensure subscriptionId is supplied.");
-            }
-            if (!azureSupportedCloudName.has(environment)) {
-                throw new Error("Unsupported value for environment is passed.The list of supported values for environment are ‘azureusgovernment', ‘azurechinacloud’, ‘azuregermancloud’, ‘azurecloud’ or ’azurestack’");
-            }
-
-            // OIDC specific checks
-            if (enableOIDC) {
-                console.log('Using OIDC authentication...')
-                try {
-                    //generating ID-token
-                    let audience = core.getInput('audience', { required: false });
-                    federatedToken = await core.getIDToken(audience);
-                    if (!!federatedToken) {
-                        if (environment != "azurecloud")
-                            throw new Error(`Your current environment - "${environment}" is not supported for OIDC login.`);
-                        let [issuer, subjectClaim] = await jwtParser(federatedToken);
-                        console.log("Federated token details: \n issuer - " + issuer + " \n subject claim - " + subjectClaim);
-                    }
+        // OIDC specific checks
+        if (enableOIDC) {
+            console.log('Using OIDC authentication...')
+            try {
+                //generating ID-token
+                let audience = core.getInput('audience', { required: false });
+                federatedToken = await core.getIDToken(audience);
+                if (!!federatedToken) {
+                    if (environment != "azurecloud")
+                        throw new Error(`Your current environment - "${environment}" is not supported for OIDC login.`);
+                    let [issuer, subjectClaim] = await jwtParser(federatedToken);
+                    console.log("Federated token details: \n issuer - " + issuer + " \n subject claim - " + subjectClaim);
                 }
-                catch (error) {
-                    core.error(`${error.message.split(':')[1]}. Please make sure to give write permissions to id-token in the workflow.`);
-                }
+            }
+            catch (error) {
+                core.error(`${error.message.split(':')[1]}. Please make sure to give write permissions to id-token in the workflow.`);
             }
         }
         
@@ -176,14 +177,15 @@ async function main() {
         console.log(`Done setting cloud: "${environment}"`);
 
         // Attempting Az cli login
+        var commonArgs = [""];
         if(useManagedIdentity){
-            var commonArgs = ["--identity"];
+            commonArgs = ["--identity"];
             if(userManagedIdentityResourceId){
                 commonArgs = commonArgs.concat("-u", userManagedIdentityResourceId);
             }
         }
         else{
-            var commonArgs = ["--service-principal",
+            commonArgs = ["--service-principal",
                 "-u", servicePrincipalId,
                 "--tenant", tenantId
             ];
@@ -202,13 +204,13 @@ async function main() {
 
         if (!allowNoSubscriptionsLogin) {
             if(!(useManagedIdentity && !userManagedIdentityResourceId)){
-                //pass when using a system-assigned managed identity
                 var args = [
                     "--subscription",
                     subscriptionId
                 ];
                 await executeAzCliCommand(`account set`, true, loginOptions, args);
             }
+            //pass when using a system-assigned managed identity
         }
         isAzCLISuccess = true;
         if (enableAzPSSession) {


### PR DESCRIPTION
### Description
This PR is going to support both system- and user- assigned managed identity login for self-hosted runners on Azure VM. 

We add two new input options:
`enable-managed-identity`: 'Set this value to true to enable Managed Identity for your action. Requires a self-hosted Github runner on an Azure VM with Managed Identity enabled.'
`user-managed-identity-resource-id`: 'Set this value to the Resource ID of your user managed identity. If using a system managed identity, leave this empty. This setting has no effect if `enable-managed-identity` is false.'

CLI Part is ready now.

### Test workflows:
[System-assigned managed identity test](https://github.com/MoChilia/ActionsDemo/actions/workflows/TestSystemManagedIdentity.yml)
[User-assigned managed identity test](https://github.com/MoChilia/ActionsDemo/actions/workflows/TestUserManagedIdentity.yml)

Related to issue #56 
With reference to pr #68 