### PR TITLE
docs: fix type in creds attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,8 @@ The command should output a JSON object similar to this:
 ```yaml
   - uses: Azure/login@v1
     with:
-      creds: '{"clientId":"${{ secrets.CLIENT_ID }}","clientSecret":"${{ secrets.CLIENT_SECRET }}","subscriptionId":"${{ secrets.SUBSCRIPTION_ID }}","tenantId":"${{ secrets.TENANT_ID }}"}'
+      creds: '{"clientId":"${{ secrets.AZURE_AD_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_AD_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_AD_TENANT_ID }}"}'
+
 ```
 
 In a similar way, any additional parameter can be added to creds such as resourceManagerEndpointUrl for Azure Stack, for example.


### PR DESCRIPTION
This PR fixes the secrets names in `creds` attribute.