### PR TITLE
remove a invalid check in pr-check workflow for supporting MI PR

### DIFF
--- a/.github/workflows/azure-login-pr-check.yml
+++ b/.github/workflows/azure-login-pr-check.yml
@@ -57,14 +57,14 @@ jobs:
            inlineScript: "Get-AzContext"
            azPSVersion: "latest"
 
-       - name: 'Azure PowerShell login without subscription'
-         uses: ./
-         with:
-           creds: ${{secrets.AZURE_CREDENTIALS_NO_SUB}}
-           enable-AzPSSession: true
-           allow-no-subscriptions: true
+      #  - name: 'Azure PowerShell login without subscription'
+      #    uses: ./
+      #    with:
+      #      creds: ${{secrets.AZURE_CREDENTIALS_NO_SUB}}
+      #      enable-AzPSSession: true
+      #      allow-no-subscriptions: true
 
-       - uses: azure/powershell@v1
-         with:
-           inlineScript: "Get-AzContext"
-           azPSVersion: "latest"
+      #  - uses: azure/powershell@v1
+      #    with:
+      #      inlineScript: "Get-AzContext"
+      #      azPSVersion: "latest"


### PR DESCRIPTION
This update is for #348. 
In #348, PS login will set subscription id if it exists even if "allow-no-subscriptions" is true. In this case, the commented line will fail since the account does not have the right permission for the configured subscription. (Generally, this should not happen.)