### PR TITLE
Fix #371: Allow optional `subscriptionId` in `creds`

### DIFF
--- a/.github/workflows/azure-login-negative.yml
+++ b/.github/workflows/azure-login-negative.yml
@@ -352,7 +352,7 @@ jobs:
       run: |
         az logout
 
-    # SP1 is ignored and SP2 will be used for login, but it will failed since SP2 has no access to the given subscription
+    # SP1 is ignored and SP2 will be used for login, but it will fail since SP2 has no access to the given subscription
     - name: Login with both creds and individual parameters
       id: login_12
       continue-on-error: true
@@ -383,6 +383,37 @@ jobs:
       
     - name: Check Last step failed
       if: steps.login_13.outcome == 'success'
+      uses: actions/github-script@v3
+      with:
+          script: |
+            core.setFailed('Last action should fail but not. Please check it.')
+    
+    - name: Login with individual parameters, no subscription-id, no allow-no-subscriptions
+      id: login_14
+      continue-on-error: true
+      uses: ./
+      with:
+        client-id: ${{ secrets.OIDC_SP2_CLIENT_ID }}
+        tenant-id: ${{ secrets.OIDC_SP2_TENANT_ID }}
+        enable-AzPSSession: true
+
+    - name: Check Last step failed
+      if: steps.login_14.outcome == 'success'
+      uses: actions/github-script@v3
+      with:
+          script: |
+            core.setFailed('Last action should fail but not. Please check it.')
+    
+    - name: Login with creds, no subscription-id, no allow-no-subscriptions
+      id: login_15
+      continue-on-error: true
+      uses: ./
+      with:
+        creds: '{"clientId":"${{ secrets.OIDC_SP2_CLIENT_ID }}","clientSecret":"${{ secrets.SP2_CLIENT_SECRET }}","tenantId":"${{ secrets.OIDC_SP2_TENANT_ID }}"}'
+        enable-AzPSSession: true
+
+    - name: Check Last step failed
+      if: steps.login_15.outcome == 'success'
       uses: actions/github-script@v3
       with:
           script: |

--- a/.github/workflows/azure-login-negative.yml
+++ b/.github/workflows/azure-login-negative.yml
@@ -347,6 +347,11 @@ jobs:
           script: |
             core.setFailed('Last action should fail but not. Please check it.')
 
+    # logout first to avoid the conflict with SP1
+    - name: Azure CLI logout
+      run: |
+        az logout
+
     # SP1 is ignored and SP2 will be used for login, but it will failed since SP2 has no access to the given subscription
     - name: Login with both creds and individual parameters
       id: login_12

--- a/.github/workflows/azure-login-negative.yml
+++ b/.github/workflows/azure-login-negative.yml
@@ -347,7 +347,7 @@ jobs:
           script: |
             core.setFailed('Last action should fail but not. Please check it.')
 
-    # Secret of SP1 in creds will be used to sign in SP2
+    # SP1 is ignored and SP2 will be used for login, but it will failed since SP2 has no access to the given subscription
     - name: Login with both creds and individual parameters
       id: login_12
       continue-on-error: true

--- a/.github/workflows/azure-login-positive.yml
+++ b/.github/workflows/azure-login-positive.yml
@@ -198,6 +198,27 @@ jobs:
                 throw "Not all checks passed!"
             }
 
+    - name: Login with creds, no subscription, allow no subscription
+      uses: ./
+      with:
+        creds: '{"clientId":"${{ secrets.OIDC_SP2_CLIENT_ID }}","clientSecret":"${{ secrets.SP2_CLIENT_SECRET }}","tenantId":"${{ secrets.OIDC_SP2_TENANT_ID }}"}'
+        allow-no-subscriptions: true
+        enable-AzPSSession: true
+
+    - name: Run Azure Cli
+      run: |
+        az account show --output none
+
+    - name: Run Azure PowerShell
+      uses: azure/powershell@v1.2.0
+      with:
+        azPSVersion: "latest"
+        inlineScript: |
+            $checkResult = (Get-AzContext).Environment.Name -eq 'AzureCloud'
+            if(-not $checkResult){
+                throw "Not all checks passed!"
+            }
+
   VMTest:
     strategy:
       matrix:

--- a/.github/workflows/azure-login-positive.yml
+++ b/.github/workflows/azure-login-positive.yml
@@ -178,9 +178,9 @@ jobs:
     - name: Login with individual parameters, allow no subscription
       uses: ./
       with:
-        client-id: ${{ secrets.OIDC_SP2_CLIENT_ID }}
-        tenant-id: ${{ secrets.OIDC_SP2_TENANT_ID}}
-        subscription-id: ${{ secrets.OIDC_SP2_TENANT_ID }}
+        client-id: ${{ secrets.SP1_CLIENT_ID }}
+        tenant-id: ${{ secrets.SP1_TENANT_ID}}
+        subscription-id: ${{ secrets.SP1_SUBSCRIPTION_ID }}
         allow-no-subscriptions: true
         enable-AzPSSession: true
 

--- a/.github/workflows/azure-login-positive.yml
+++ b/.github/workflows/azure-login-positive.yml
@@ -61,10 +61,9 @@ jobs:
     - name: Login with individual parameters
       uses: ./
       with:
-        client-id: ${{ secrets.OIDC_SP2_CLIENT_ID }}
-        tenant-id: ${{ secrets.OIDC_SP2_TENANT_ID }}
-        # subscription-id: ${{ secrets.OIDC_SP2_SUBSCRIPTION_ID }}
-        allow-no-subscriptions: true
+        client-id: ${{ secrets.SP1_CLIENT_ID }}
+        tenant-id: ${{ secrets.SP1_TENANT_ID }}
+        subscription-id: ${{ secrets.SP1_SUBSCRIPTION_ID }}
         enable-AzPSSession: true
 
     - name: Run Azure Cli again
@@ -172,6 +171,29 @@ jobs:
             $checkResult = (Get-AzContext).Environment.Name -eq 'AzureCloud'
             $checkResult = $checkResult -and ((Get-AzResourceGroup -Name GitHubAction_CI_RG).ResourceGroupName -eq 'GitHubAction_CI_RG')
             $checkResult = $checkResult -and ((Get-AzVM).Count -gt 0)
+            if(-not $checkResult){
+                throw "Not all checks passed!"
+            }
+
+    - name: Login with individual parameters, allow no subscription
+      uses: ./
+      with:
+        client-id: ${{ secrets.OIDC_SP2_CLIENT_ID }}
+        tenant-id: ${{ secrets.OIDC_SP2_TENANT_ID}}
+        subscription-id: ${{ secrets.OIDC_SP2_TENANT_ID }}
+        allow-no-subscriptions: true
+        enable-AzPSSession: true
+
+    - name: Run Azure Cli again
+      run: |
+        az account show --output none
+
+    - name: Run Azure PowerShell again
+      uses: azure/powershell@v1.2.0
+      with:
+        azPSVersion: "latest"
+        inlineScript: |
+            $checkResult = (Get-AzContext).Environment.Name -eq 'AzureCloud'
             if(-not $checkResult){
                 throw "Not all checks passed!"
             }

--- a/__tests__/LoginConfig.test.ts
+++ b/__tests__/LoginConfig.test.ts
@@ -75,6 +75,32 @@ describe("LoginConfig Test", () => {
 
     });
 
+    
+    test('initialize with creds, lack of  subscriptionId, but allowNoSubscriptionsLogin=true', async () => {
+        let creds1 = {
+            'clientId': 'client-id',
+            'clientSecret': 'client-secret',
+            'tenantId': 'tenant-id',
+            // 'subscriptionId': 'subscription-id'
+        }
+        setEnv('environment', 'azurecloud');
+        setEnv('enable-AzPSSession', 'true');
+        setEnv('allow-no-subscriptions', 'true');
+        setEnv('auth-type', 'SERVICE_PRINCIPAL');
+        setEnv('creds', JSON.stringify(creds1));
+        let loginConfig = new LoginConfig();
+        await loginConfig.initialize();
+        expect(loginConfig.environment).toBe("azurecloud");
+        expect(loginConfig.enableAzPSSession).toBeTruthy();
+        expect(loginConfig.allowNoSubscriptionsLogin).toBeTruthy();
+        expect(loginConfig.authType).toBe("SERVICE_PRINCIPAL");
+        expect(loginConfig.servicePrincipalId).toBe("client-id");
+        expect(loginConfig.servicePrincipalSecret).toBe("client-secret");
+        expect(loginConfig.tenantId).toBe("tenant-id");
+        expect(loginConfig.subscriptionId).toBe("");
+    });
+
+
     test('initialize with creds', async () => {
         let creds = {
             'clientId': 'client-id',

--- a/__tests__/LoginConfig.test.ts
+++ b/__tests__/LoginConfig.test.ts
@@ -74,9 +74,8 @@ describe("LoginConfig Test", () => {
         await testCreds(creds1);
 
     });
-
-    
-    test('initialize with creds, lack of  subscriptionId, but allowNoSubscriptionsLogin=true', async () => {
+   
+    test('initialize with creds, lack of subscriptionId, but allowNoSubscriptionsLogin=true', async () => {
         let creds1 = {
             'clientId': 'client-id',
             'clientSecret': 'client-secret',
@@ -99,7 +98,6 @@ describe("LoginConfig Test", () => {
         expect(loginConfig.tenantId).toBe("tenant-id");
         expect(loginConfig.subscriptionId).toBe("");
     });
-
 
     test('initialize with creds', async () => {
         let creds = {

--- a/__tests__/LoginConfig.test.ts
+++ b/__tests__/LoginConfig.test.ts
@@ -75,17 +75,6 @@ describe("LoginConfig Test", () => {
 
     });
 
-    test('initialize with creds, lack of subscriptionId', async () => {
-        let creds1 = {
-            'clientId': 'client-id',
-            'clientSecret': 'client-secret',
-            'tenantId': 'tenant-id',
-            // 'subscriptionId': 'subscription-id'
-        }
-        await testCreds(creds1);
-
-    });
-
     test('initialize with creds', async () => {
         let creds = {
             'clientId': 'client-id',

--- a/src/Cli/AzureCliLogin.ts
+++ b/src/Cli/AzureCliLogin.ts
@@ -126,14 +126,13 @@ export class AzureCliLogin {
             args.push("--allow-no-subscriptions");
         }
         await this.executeAzCliCommand(args, true, this.loginOptions);
-        await this.setSubscription();
+        if (this.loginConfig.subscriptionId) {
+            await this.setSubscription();
+        }
         core.info(`Azure CLI login succeeds by using ${methodName}.`);
     }
 
     async setSubscription() {
-        if (!this.loginConfig.subscriptionId) {
-            return;
-        }
         let args = ["account", "set", "--subscription", this.loginConfig.subscriptionId];
         await this.executeAzCliCommand(args, true, this.loginOptions);
         core.info("Subscription is set successfully.");
@@ -160,7 +159,7 @@ function defaultExecOptions(): exec.ExecOptions {
                 if (error && error.trim().length !== 0 && !startsWithWarning) {
                     if (startsWithError) {
                         //removing the keyword 'ERROR' to avoid duplicates while throwing error
-                        error = error.slice(5);
+                        error = error.slice(7);
                     }
                     core.error(error);
                 }

--- a/src/Cli/AzureCliLogin.ts
+++ b/src/Cli/AzureCliLogin.ts
@@ -131,7 +131,7 @@ export class AzureCliLogin {
     }
 
     async setSubscription() {
-        if (this.loginConfig.allowNoSubscriptionsLogin) {
+        if (!this.loginConfig.subscriptionId) {
             return;
         }
         let args = ["account", "set", "--subscription", this.loginConfig.subscriptionId];

--- a/src/common/LoginConfig.ts
+++ b/src/common/LoginConfig.ts
@@ -69,8 +69,8 @@ export class LoginConfig {
         this.tenantId = this.tenantId ? this.tenantId : secrets.getSecret("$.tenantId", false);
         this.subscriptionId = this.subscriptionId ? this.subscriptionId : secrets.getSecret("$.subscriptionId", false);
         this.resourceManagerEndpointUrl = secrets.getSecret("$.resourceManagerEndpointUrl", false);
-        if (!this.servicePrincipalId || !this.servicePrincipalSecret || !this.tenantId || !this.subscriptionId) {
-            throw new Error("Not all parameters are provided in 'creds'. Double-check if all keys are defined in 'creds': 'clientId', 'clientSecret', 'subscriptionId', 'tenantId'.");
+        if (!this.servicePrincipalId || !this.servicePrincipalSecret || !this.tenantId) {
+            throw new Error("Not all parameters are provided in 'creds'. Double-check if all keys are defined in 'creds': 'clientId', 'clientSecret', 'tenantId'.");
         }
     }
 


### PR DESCRIPTION
### Description
This pr will remove the mandatory requirement of `subscriptionId` in `creds` to solve #371. 

| subscription-id | allow-no-subscriptions | Log in successfully | Test | 
| :---: | :---: | :---:  | :--- | 
| :heavy_check_mark: | :x: |  :heavy_check_mark: | Creds: https://github.com/Azure/login/blob/7acbecf424173a875bf7db0d5fd041a53769e699/.github/workflows/azure-login-positive.yml#L37-L41 OIDC: https://github.com/Azure/login/blob/7acbecf424173a875bf7db0d5fd041a53769e699/.github/workflows/azure-login-positive.yml#L61-L67|
| :x: | :heavy_check_mark: | :heavy_check_mark: | Creds: https://github.com/Azure/login/blob/7acbecf424173a875bf7db0d5fd041a53769e699/.github/workflows/azure-login-positive.yml#L223-L228 OIDC: https://github.com/Azure/login/blob/7acbecf424173a875bf7db0d5fd041a53769e699/.github/workflows/azure-login-positive.yml#L201-L207|
| :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | Creds: https://github.com/Azure/login/blob/7acbecf424173a875bf7db0d5fd041a53769e699/.github/workflows/azure-login-positive.yml#L153-L158 OIDC: https://github.com/Azure/login/blob/7acbecf424173a875bf7db0d5fd041a53769e699/.github/workflows/azure-login-positive.yml#L178-L185|
| :x: | :x: | :x: | Creds: https://github.com/Azure/login/blob/7acbecf424173a875bf7db0d5fd041a53769e699/.github/workflows/azure-login-negative.yml#L407-L413 OIDC: https://github.com/Azure/login/blob/7acbecf424173a875bf7db0d5fd041a53769e699/.github/workflows/azure-login-negative.yml#L391-L398|

Validation for both `subscription-id` and `allow-no-subscriptions` are missed: 
https://github.com/Azure/login/blob/31435a1ad28627a6fd370066fca1073bfdba2bd6/src/common/LoginConfig.ts#L102-L104

If `subscription-id` is given, then set the subscription:
https://github.com/Azure/login/blob/31435a1ad28627a6fd370066fca1073bfdba2bd6/src/Cli/AzureCliLogin.ts#L129-L131
https://github.com/Azure/login/blob/31435a1ad28627a6fd370066fca1073bfdba2bd6/src/PowerShell/AzPSScriptBuilder.ts#L106-L108

Negative test for login tenant-level account with subscription-id (no permission to subscriptions):
https://github.com/Azure/login/blob/7acbecf424173a875bf7db0d5fd041a53769e699/.github/workflows/azure-login-negative.yml#L355-L373