### PR TITLE
Azure/login should logout the active account at the beginning

### DIFF
--- a/.github/workflows/azure-login-negative.yml
+++ b/.github/workflows/azure-login-negative.yml
@@ -347,11 +347,6 @@ jobs:
           script: |
             core.setFailed('Last action should fail but not. Please check it.')
 
-    # logout first to avoid the conflict with SP1
-    - name: Azure CLI logout
-      run: |
-        az logout
-
     # SP1 is ignored and SP2 will be used for login, but it will fail since SP2 has no access to the given subscription
     - name: Login with both creds and individual parameters
       id: login_12

--- a/src/Cli/AzureCliLogin.ts
+++ b/src/Cli/AzureCliLogin.ts
@@ -34,6 +34,13 @@ export class AzureCliLogin {
         await this.executeAzCliCommand(["--version"], true, execOptions);
         core.debug(`Azure CLI version used:\n${output}`);
 
+        try {
+            await this.executeAzCliCommand(["logout"], true, execOptions);
+        }
+        catch (error) {
+            core.debug(`Ignore logout error: "${error}"`);
+        }
+
         this.setAzurestackEnvIfNecessary();
 
         await this.executeAzCliCommand(["cloud", "set", "-n", this.loginConfig.environment], false);


### PR DESCRIPTION
Azure CLI should run `az logout` to clear the active account at the beginning like what is done in Azure PowerShell: 
https://github.com/Azure/login/blob/34b958dce7c4a4190d4bd0a81255bef97f2e5cf5/src/PowerShell/AzPSScriptBuilder.ts#L27-L28
Otherwise, when the user doesn't explicitly give the `subscription-id` or the given `subscription-id` is invaild, the post steps will continue using the user's active subscription which has set last time and not logged out. 

The following test case will encounter this issue: https://github.com/Azure/login/blob/34b958dce7c4a4190d4bd0a81255bef97f2e5cf5/.github/workflows/azure-login-negative.yml#L355-L366