### PR TITLE
Run `az account clear` instead of `az logout` at the beginning

### DIFF
--- a/src/Cli/AzureCliLogin.ts
+++ b/src/Cli/AzureCliLogin.ts
@@ -35,10 +35,10 @@ export class AzureCliLogin {
         core.debug(`Azure CLI version used:\n${output}`);
 
         try {
-            await this.executeAzCliCommand(["logout"], true, execOptions);
+            await this.executeAzCliCommand(["account", "clear"], true, execOptions);
         }
         catch (error) {
-            core.debug(`Ignore logout error: "${error}"`);
+            core.debug(`Ignore account clear error: "${error}"`);
         }
 
         this.setAzurestackEnvIfNecessary();

--- a/src/Cli/AzureCliLogin.ts
+++ b/src/Cli/AzureCliLogin.ts
@@ -34,12 +34,7 @@ export class AzureCliLogin {
         await this.executeAzCliCommand(["--version"], true, execOptions);
         core.debug(`Azure CLI version used:\n${output}`);
 
-        try {
-            await this.executeAzCliCommand(["account", "clear"], true, execOptions);
-        }
-        catch (error) {
-            core.debug(`Ignore account clear error: "${error}"`);
-        }
+        await this.executeAzCliCommand(["account", "clear"], true, execOptions);
 
         this.setAzurestackEnvIfNecessary();
 


### PR DESCRIPTION
Modify the code in #376. 
As it described in Azure CLI, [az account clear](https://learn.microsoft.com/en-us/cli/azure/account?view=azure-cli-latest#az-account-clear) will clear all subscriptions from the CLI's local cache. And [az logout](https://learn.microsoft.com/en-us/cli/azure/reference-index?view=azure-cli-latest#az-logout) will log out the current active account.
In automation, `az account clear` should be a better choice for a cleaner environment.