### PR TITLE
Update `actions-secret-parser` from `1.0.2` to `1.0.4`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@actions/core": "1.9.1",
         "@actions/exec": "^1.0.1",
         "@actions/io": "^1.0.1",
-        "actions-secret-parser": "^1.0.2",
+        "actions-secret-parser": "^1.0.4",
         "package-lock": "^1.0.3"
       },
       "devDependencies": {
@@ -1137,11 +1137,11 @@
       "dev": true
     },
     "node_modules/actions-secret-parser": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/actions-secret-parser/-/actions-secret-parser-1.0.3.tgz",
-      "integrity": "sha512-+iGlMSsE/cbxDaEZlqR0NUjn35DckMYsdYFwVeZ7JRbtyO/AiBKnaScKkzkHSoiZ4nEPTdIHtMpRGVgoeVYX+A==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/actions-secret-parser/-/actions-secret-parser-1.0.4.tgz",
+      "integrity": "sha512-gDAB8GK2Vj9CN5r97DZlmpxqrMcpAGKGWiIY3hpFhJMieLpl3K3ocVR49/Q4ANaA5a/2wNRE3Qng+x0K8mkmkQ==",
       "dependencies": {
-        "@actions/core": "^1.1.3",
+        "@actions/core": "^1.1.10",
         "jsonpath": "^1.0.2",
         "xmldom": "^0.1.27",
         "xpath": "0.0.27"
@@ -4741,11 +4741,11 @@
       "dev": true
     },
     "actions-secret-parser": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/actions-secret-parser/-/actions-secret-parser-1.0.3.tgz",
-      "integrity": "sha512-+iGlMSsE/cbxDaEZlqR0NUjn35DckMYsdYFwVeZ7JRbtyO/AiBKnaScKkzkHSoiZ4nEPTdIHtMpRGVgoeVYX+A==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/actions-secret-parser/-/actions-secret-parser-1.0.4.tgz",
+      "integrity": "sha512-gDAB8GK2Vj9CN5r97DZlmpxqrMcpAGKGWiIY3hpFhJMieLpl3K3ocVR49/Q4ANaA5a/2wNRE3Qng+x0K8mkmkQ==",
       "requires": {
-        "@actions/core": "^1.1.3",
+        "@actions/core": "^1.1.10",
         "jsonpath": "^1.0.2",
         "xmldom": "^0.1.27",
         "xpath": "0.0.27"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@actions/core": "1.9.1",
     "@actions/exec": "^1.0.1",
     "@actions/io": "^1.0.1",
-    "actions-secret-parser": "^1.0.2",
+    "actions-secret-parser": "^1.0.4",
     "package-lock": "^1.0.3"
   }
 }


### PR DESCRIPTION
## Description
A deprecation warning occurred in the package `actions-secret-parser`:
```
(node:1918) [DEP0128] DeprecationWarning: Invalid 'main' field in '/home/runner/work/login/login/node_modules/actions-secret-parser/package.json' of 'lib/index.js'. Please either fix that or report it to the module author
```
See https://github.com/Azure/login/actions/runs/7027432479/job/19122197079#step:5:10.

Hence, this pr will update its version to the latest `1.0.4` to solve the warning. See https://www.npmjs.com/package/actions-secret-parser.