### PR TITLE
Force failure

### DIFF
--- a/.github/workflows/azure-login-negative.yml
+++ b/.github/workflows/azure-login-negative.yml
@@ -51,6 +51,7 @@ jobs:
           (Get-AzContext).Environment.Name -eq 'AzureCloud'
           (Get-AzResourceGroup -Name GitHubAction_CI_RG).ResourceGroupName -eq 'GitHubAction_CI_RG'
           (Get-AzVM).Count -gt 0
+          exit 1
 
     - name: Check Last step failed
       if: steps.ps_1.outcome == 'success'


### PR DESCRIPTION
Address https://github.com/Azure/login/pull/385#discussion_r1436709259

> As azure/powershell@v1 now supports macOS, we
> need a new way to trigger a failure to show that
> ps steps can fail and their failings can be handled.

I'm not particularly fond of this fix. It depends on what the goal of this step was, and I can't really tell. I looked at the various steps that this workflow had and it seems to have evolved a number of times. The current construct seems pretty complicated for something that's just interested in the exit code of an action (which in turn is dependent on it not supporting the tested platform).

It could be simplified to just `exit 1` instead of retaining the current commands (which previously were never run).