### PR TITLE
Limit pr-check permissions

### DIFF
--- a/.github/workflows/azure-login-pr-check.yml
+++ b/.github/workflows/azure-login-pr-check.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
       - 'releases/*'
+
+permissions:
+  contents: read
+
 jobs:
    az-login-test:
      environment: Automation test


### PR DESCRIPTION
Afaict, this workflow does **not** need any interesting [`GITHUB_TOKEN` permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret).

It only needs `contents: read` if it's imported into a private repository (which is something that one might do if one were testing a PR like this).

If it needs `id-token: write`, it should be explicit about that, but based on my reading, it doesn't, as the steps all use `with:`/`creds:`.

Note that as-is, this isn't a security item because this workflow requires approval to run (and given that running it explicitly allows PRs to use an azure credential, I have faith that reviewers are considering the contents of PRs before approving them...).