### PR TITLE
Update Action to use Node.js v20

### DIFF
--- a/.github/workflows/azure-login-negative.yml
+++ b/.github/workflows/azure-login-negative.yml
@@ -21,10 +21,10 @@ jobs:
     - name: 'Checking out repo code'
       uses: actions/checkout@v4
 
-    - name: Set Node.js 16.x for GitHub Action
+    - name: Set Node.js 20.x for GitHub Action
       uses: actions/setup-node@v4
       with:
-        node-version: 16.x
+        node-version: 20.x
 
     - name: 'Validate build'
       run: |
@@ -84,10 +84,10 @@ jobs:
     - name: 'Checking out repo code'
       uses: actions/checkout@v4
 
-    - name: Set Node.js 16.x for GitHub Action
+    - name: Set Node.js 20.x for GitHub Action
       uses: actions/setup-node@v4
       with:
-        node-version: 16.x
+        node-version: 20.x
 
     - name: 'Validate build'
       run: |
@@ -345,10 +345,10 @@ jobs:
     - name: 'Checking out repo code'
       uses: actions/checkout@v4
 
-    - name: Set Node.js 16.x for GitHub Action
+    - name: Set Node.js 20.x for GitHub Action
       uses: actions/setup-node@v4
       with:
-        node-version: 16.x
+        node-version: 20.x
 
     - name: 'Validate build'
       run: |

--- a/.github/workflows/azure-login-positive.yml
+++ b/.github/workflows/azure-login-positive.yml
@@ -20,10 +20,10 @@ jobs:
     - name: 'Checking out repo code'
       uses: actions/checkout@v4
 
-    - name: Set Node.js 16.x for GitHub Action
+    - name: Set Node.js 20.x for GitHub Action
       uses: actions/setup-node@v4
       with:
-        node-version: 16.x
+        node-version: 20.x
 
     - name: 'Validate build'
       run: |
@@ -116,10 +116,10 @@ jobs:
     - name: 'Checking out repo code'
       uses: actions/checkout@v4
 
-    - name: Set Node.js 16.x for GitHub Action
+    - name: Set Node.js 20.x for GitHub Action
       uses: actions/setup-node@v4
       with:
-        node-version: 16.x
+        node-version: 20.x
 
     - name: 'Validate build'
       run: |
@@ -256,10 +256,10 @@ jobs:
     - name: 'Checking out repo code'
       uses: actions/checkout@v4
 
-    - name: Set Node.js 16.x for GitHub Action
+    - name: Set Node.js 20.x for GitHub Action
       uses: actions/setup-node@v4
       with:
-        node-version: 16.x
+        node-version: 20.x
 
     - name: 'Validate build'
       run: |

--- a/.github/workflows/azure-login-pr-check.yml
+++ b/.github/workflows/azure-login-pr-check.yml
@@ -16,11 +16,11 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
 
-         # Using 16.x version as an example
-       - name: Set Node.js 16.x for GitHub Action
+         # Using 20.x version as an example
+       - name: Set Node.js 20.x for GitHub Action
          uses: actions/setup-node@v4
          with:
-           node-version: 16.x
+           node-version: 20.x
 
        - name: installing node_modules
          run: npm install 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,16 +20,16 @@ jobs:
     - name: 'Checking out repo code'
       uses: actions/checkout@v4
 
-    - name: Set Node.js 16.x for GitHub Action
+    - name: Set Node.js 20.x for GitHub Action
       uses: actions/setup-node@v4
       with:
-        node-version: 16.x
+        node-version: 20.x
 
     - name: 'Validate build'
       run: |
         npm install
         npm run build
-        
+
     - name: 'Run L0 tests'
       run: |
         npm run test

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
       - name: Run Markdownlint
         run: |
           npm i -g markdownlint-cli2

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 # Login to Azure subscription
 name: 'Azure Login'
 description: 'Authenticate to Azure and run your Azure CLI or Azure PowerShell based actions or scripts.'
-inputs: 
+inputs:
   creds:
     description: 'Paste output of `az ad sp create-for-rbac` as value of secret variable: AZURE_CREDENTIALS'
     required: false
@@ -14,7 +14,7 @@ inputs:
   subscription-id:
     description: 'Azure subscriptionId'
     required: false
-  enable-AzPSSession: 
+  enable-AzPSSession:
     description: 'Set this value to true to enable Azure PowerShell Login in addition to Azure CLI login'
     required: false
     default: false
@@ -27,18 +27,18 @@ inputs:
     required: false
     default: false
   audience:
-    description: 'Provide audience field for access-token. Default value is api://AzureADTokenExchange' 
+    description: 'Provide audience field for access-token. Default value is api://AzureADTokenExchange'
     required: false
     default: 'api://AzureADTokenExchange'
   auth-type:
-    description: 'The type of authentication. Supported values are SERVICE_PRINCIPAL, IDENTITY. Default value is SERVICE_PRINCIPAL' 
+    description: 'The type of authentication. Supported values are SERVICE_PRINCIPAL, IDENTITY. Default value is SERVICE_PRINCIPAL'
     required: false
     default: 'SERVICE_PRINCIPAL'
 branding:
   icon: 'login.svg'
   color: 'blue'
 runs:
-  using: 'node16'
+  using: 'node20'
   pre: 'lib/cleanup.js'
   main: 'lib/main.js'
   post: 'lib/cleanup.js'


### PR DESCRIPTION
Node.js 16 actions are deprecated.
Updating action to use Node.js 20.

Link: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Fixes #357 