### PR TITLE
Temporarily change CI test due to a bug in Azure PowerShell

### DIFF
--- a/.github/workflows/azure-login-positive.yml
+++ b/.github/workflows/azure-login-positive.yml
@@ -219,7 +219,7 @@ jobs:
       with:
         azPSVersion: "latest"
         inlineScript: |
-            $checkResult = (Get-AzContext -ListAvailable).Count -eq 2
+            $checkResult = (Get-AzContext).Environment.Name -eq 'AzureCloud'
             if(-not $checkResult){
               throw "Not all checks passed!"
             }


### PR DESCRIPTION
`Get-AzContext -ListAvailable` suddenly doesn't work with `Az.Accounts 2.15.1`. The bug has been reported in https://github.com/Azure/azure-powershell/issues/24179. 