### PR TITLE
Fix CodeQL error: `Resource not accessible by integration` & Update CodeQL version

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,11 @@ on:
   schedule:
     - cron: '0 19 * * 0'
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
   CodeQL-Build:
 
@@ -18,14 +23,14 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: javascript
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -39,4 +44,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
1. Add permission for the workflow to fix the error: CodeQL-Build: `Resource not accessible by integration`. This is due to the permission change in GitHub Action: https://docs.opensource.microsoft.com/github/apps/permission-changes/.

2. Update CodeQL version from v2 to v3 to fix the warning: CodeQL-Build: `CodeQL Action v2 will be deprecated on December 5th, 2024. Please update all occurrences of the CodeQL Action in your workflow files to v3. For more information, see https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/`

Example: [workflow](https://github.com/Azure/login/actions/runs/7968034490)
