### PR TITLE
Use `@vercel/ncc` to compile Azure/login

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,6 @@ branding:
   color: 'blue'
 runs:
   using: 'node20'
-  pre: 'lib/cleanup.js'
-  main: 'lib/main.js'
-  post: 'lib/cleanup.js'
+  pre: 'lib/cleanup/index.js'
+  main: 'lib/main/index.js'
+  post: 'lib/cleanup/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "login",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "login",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "1.9.1",
@@ -17,6 +17,7 @@
       "devDependencies": {
         "@types/jest": "^29.2.4",
         "@types/node": "^20.11.1",
+        "@vercel/ncc": "^0.38.1",
         "jest": "^29.3.1",
         "jest-circus": "^29.3.1",
         "ts-jest": "^29.0.3",
@@ -1105,6 +1106,15 @@
       "version": "21.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vercel/ncc": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.1.tgz",
+      "integrity": "sha512-IBBb+iI2NLu4VQn3Vwldyi2QwaXt5+hTyh58ggAMoCGE6DJmPvwL3KPBWcJl1m9LYPChBLE980Jw+CS4Wokqxw==",
+      "dev": true,
+      "bin": {
+        "ncc": "dist/ncc/cli.js"
+      }
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "login",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Login Azure wraps the az login, allowing for Azure actions to log into Azure",
-  "main": "lib/main.js",
+  "main": "lib/main/index.js",
   "scripts": {
-    "build": "tsc",
+    "build:main": "ncc build src/main.ts -o lib/main",
+    "build:cleanup": "ncc build src/cleanup.ts -o lib/cleanup",
+    "build": "npm run build:main && npm run build:cleanup",
     "test": "jest"
   },
   "author": "Microsoft",
@@ -12,6 +14,7 @@
   "devDependencies": {
     "@types/jest": "^29.2.4",
     "@types/node": "^20.11.1",
+    "@vercel/ncc": "^0.38.1",
     "jest": "^29.3.1",
     "jest-circus": "^29.3.1",
     "ts-jest": "^29.0.3",


### PR DESCRIPTION
Since `@vercel/ncc` is recommended in the [GitHub official documentation](https://docs.github.com/en/actions/creating-actions/creating-a-javascript-action#commit-tag-and-push-your-action-to-github) (also see the usage in [Azure/cli](https://github.com/Azure/cli)) for compiling code and modules into a single file for distribution, we plan to utilize this tool to minimize the package size and setup time for Azure/login.

The package size is reduced from `88MB` to `550KB`.
![image](https://github.com/Azure/login/assets/72982571/3849162d-ecd1-4850-ac79-3b3273bc896b)

The setup time is reduced from avg `4s` (may be longer on self-hosted runner, see https://github.com/Azure/login/issues/103) to less than `1s`.
![image](https://github.com/Azure/login/assets/72982571/ca7914ff-717f-4628-9d97-84b35586bb15)
![image](https://github.com/Azure/login/assets/72982571/b342a553-5849-4c75-a483-51893f680bfa)
 

Thanks @kWozniak-tt, for bringing this to our attention and for your valuable contribution in https://github.com/Azure/login/pull/367 to this topic!

Close https://github.com/Azure/login/issues/366