### PR TITLE
Enhance `pre/post` cleanup by bypassing GitHub-hosted runners

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ branding:
 runs:
   using: 'node20'
   pre: 'lib/cleanup/index.js'
-  pre-if: ${{ ! startsWith( runner.name, 'GitHub Actions' ) }}
+  pre-if: (! startsWith(runner.name, 'GitHub Actions'))
   main: 'lib/main/index.js'
   post: 'lib/cleanup/index.js'
-  post-if: ${{ ! startsWith( runner.name, 'GitHub Actions' ) }}
+  post-if: (! startsWith(runner.name, 'GitHub Actions'))

--- a/action.yml
+++ b/action.yml
@@ -40,5 +40,7 @@ branding:
 runs:
   using: 'node20'
   pre: 'lib/cleanup/index.js'
+  pre-if: ${{ ! startsWith( runner.name, 'GitHub Actions' ) }}
   main: 'lib/main/index.js'
   post: 'lib/cleanup/index.js'
+  post-if: ${{ ! startsWith( runner.name, 'GitHub Actions' ) }}

--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ branding:
 runs:
   using: 'node20'
   pre: 'lib/cleanup/index.js'
-  pre-if: (! startsWith(runner.name, 'GitHub Actions'))
+  pre-if: (! env.AZURE_LOGIN_PRE_CLEANUP_OFF)
   main: 'lib/main/index.js'
   post: 'lib/cleanup/index.js'
-  post-if: (! startsWith(runner.name, 'GitHub Actions'))
+  post-if: (! env.AZURE_LOGIN_POST_CLEANUP_OFF)


### PR DESCRIPTION
The purpose of `pre/post` cleanup is to ensure no Azure account remains active before and after a job containing `azure/login`. This measure prevents incorrect operations on unexpected Azure accounts and protects against the disclosure of Azure accounts.

However, certain scenarios are ephemeral for only one job and don't need `pre/post` cleanup. Two main scenarios fall into this category:

1. **GitHub-hosted runners**: A GitHub-hosted runner is on a VM that gets re-imaged for every job. Once the job finishes, the VM is automatically decommissioned (see [Using a GitHub-hosted runner](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#using-a-github-hosted-runner)). Since the VM is ephemeral, we can bypass this scenario to save time for our users. This bypass will be implemented in this PR. To detect whether a runner is GitHub-hosted, I refer to the solution [here](https://github.com/orgs/community/discussions/48359#discussioncomment-5323864).
2. **Running an ephemeral container on a self-hosted runner**: This scenario, as described in (https://github.com/Azure/login/issues/403#issuecomment-1893945688, involves running a container on a self-hosted runner where `az` is not pre-installed. We address this scenario by implementing PR https://github.com/Azure/login/pull/407.

With this PR merged, it is assumed that `pre/post` cleanup will only take effect in scenarios where it is truly required.

- Close https://github.com/Azure/login/issues/426