### PR TITLE
Update `azure/CLI@v1` to `azure/cli@v2` and `azure/powershell@v1` to `azure/powershell@v2`

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ on: [push]
 permissions:
       id-token: write
       contents: read
-jobs: 
+jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
@@ -195,9 +195,9 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-  
+
       - name: Azure CLI script
-        uses: azure/CLI@v1
+        uses: azure/cli@v2
         with:
           azcliversion: latest
           inlineScript: |
@@ -215,7 +215,7 @@ on: [push]
 permissions:
       id-token: write
       contents: read
-jobs: 
+jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
@@ -226,16 +226,16 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           enable-AzPSSession: true
-  
+
       - name: Azure CLI script
-        uses: azure/CLI@v1
+        uses: azure/cli@v2
         with:
           azcliversion: latest
           inlineScript: |
             az account show
 
       - name: Azure PowerShell script
-        uses: azure/powershell@v1
+        uses: azure/powershell@v2
         with:
           azPSVersion: "latest"
           inlineScript: |
@@ -281,18 +281,17 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-    
+
     - uses: azure/login@v2
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
-    
+
     - name: Azure CLI script
-      uses: azure/CLI@v1
+      uses: azure/cli@v2
       with:
         azcliversion: latest
         inlineScript: |
           az account show
-
 ```
 
 - **The workflow sample to run both Azure CLI and Azure PowerShell**
@@ -309,21 +308,21 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-    
+
     - uses: azure/login@v2
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
         enable-AzPSSession: true
-    
+
     - name: Azure CLI script
-      uses: azure/CLI@v1
+      uses: azure/cli@v2
       with:
         azcliversion: latest
         inlineScript: |
           az account show
 
     - name: Azure PowerShell script
-      uses: azure/powershell@v1
+      uses: azure/powershell@v2
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -372,29 +371,29 @@ Now you can try the workflow to login with system-assigned managed identity.
 name: Run Azure Login with System-assigned Managed Identity
 on: [push]
 
-jobs: 
+jobs:
   build-and-deploy:
     runs-on: self-hosted
     steps:
       - name: Azure login
         uses: azure/login@v2
         with:
-          auth-type: IDENTITY          
+          auth-type: IDENTITY
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           enable-AzPSSession: true
 
-      # Azure CLI Action only supports linux self-hosted runners for now. 
-      # If you want to execute the Azure CLI script on a windows self-hosted runner, you can execute it directly in `run`.  
+      # Azure CLI Action only supports linux self-hosted runners for now.
+      # If you want to execute the Azure CLI script on a windows self-hosted runner, you can execute it directly in `run`.
       - name: Azure CLI script
-        uses: azure/CLI@v1
+        uses: azure/cli@v2
         with:
           azcliversion: latest
           inlineScript: |
             az account show
 
       - name: Azure PowerShell script
-        uses: azure/powershell@v1
+        uses: azure/powershell@v2
         with:
           azPSVersion: "latest"
           inlineScript: |
@@ -438,7 +437,7 @@ Now you can try the workflow to login with user-assigned managed identity.
 name: Run Azure Login with User-assigned Managed Identity
 on: [push]
 
-jobs: 
+jobs:
   build-and-deploy:
     runs-on: self-hosted
     steps:
@@ -446,22 +445,22 @@ jobs:
         uses: azure/login@v2
         with:
           auth-type: IDENTITY
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}          
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           enable-AzPSSession: true
 
-      # Azure CLI Action only supports linux self-hosted runners for now. 
-      # If you want to execute the Azure CLI script on a windows self-hosted runner, you can execute it directly in `run`. 
+      # Azure CLI Action only supports linux self-hosted runners for now.
+      # If you want to execute the Azure CLI script on a windows self-hosted runner, you can execute it directly in `run`.
       - name: Azure CLI script
-        uses: azure/CLI@v1
+        uses: azure/cli@v2
         with:
           azcliversion: latest
           inlineScript: |
             az account show
 
       - name: Azure PowerShell script
-        uses: azure/powershell@v1
+        uses: azure/powershell@v2
         with:
           azPSVersion: "latest"
           inlineScript: |
@@ -482,13 +481,12 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-    
+
     - uses: azure/login@v2
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
         environment: 'AzureUSGovernment'
         enable-AzPSSession: true
-    
 ```
 
 ### Login to Azure Stack Hub
@@ -505,13 +503,12 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-    
+
     - uses: azure/login@v2
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
         environment: 'AzureStack'
         enable-AzPSSession: true
-    
 ```
 
 Refer to the [Azure Stack Hub Login Action Tutorial](https://learn.microsoft.com/azure-stack/user/ci-cd-github-action-login-cli) for more detailed instructions.
@@ -542,14 +539,14 @@ jobs:
         enable-AzPSSession: true
 
     - name: Azure CLI script
-      uses: azure/CLI@v1
+      uses: azure/cli@v2
       with:
         azcliversion: latest
         inlineScript: |
           az account show
 
     - name: Run Azure PowerShell
-      uses: azure/powershell@v1
+      uses: azure/powershell@v2
       with:
         azPSVersion: "latest"
         inlineScript: |

--- a/README.md
+++ b/README.md
@@ -183,8 +183,8 @@ name: Run Azure Login with OIDC
 on: [push]
 
 permissions:
-      id-token: write
-      contents: read
+  id-token: write
+  contents: read
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -213,8 +213,8 @@ name: Run Azure Login with OIDC
 on: [push]
 
 permissions:
-      id-token: write
-      contents: read
+  id-token: write
+  contents: read
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update `azure/CLI@v1` to `azure/cli@v2` and `azure/powershell@v1` to `azure/powershell@v2`:

- https://github.com/marketplace/actions/azure-cli-action
- https://github.com/marketplace/actions/azure-powershell-action

as using old versions will show a warning:

![image](https://github.com/Azure/login/assets/4003950/1b175ce8-7d06-485b-b9db-4cba23739464)

Also, according to https://github.com/marketplace/actions/azure-cli-action, the official name of Azure CLI Action is `azure/cli`, not `azure/CLI`:

![image](https://github.com/Azure/login/assets/4003950/d7596f64-68ed-4e9a-ace7-8795db2c2b9c)
