### PR TITLE
Replace `az --version` with `az version`

### DIFF
--- a/src/Cli/AzureCliLogin.ts
+++ b/src/Cli/AzureCliLogin.ts
@@ -28,7 +28,7 @@ export class AzureCliLogin {
             }
         };
 
-        await this.executeAzCliCommand(["--version"], true, execOptions);
+        await this.executeAzCliCommand(["version"], true, execOptions);
         core.debug(`Azure CLI version used:\n${output}`);
 
         this.setAzurestackEnvIfNecessary();


### PR DESCRIPTION
Related to https://github.com/Azure/login/issues/449

As noted in https://github.com/Azure/azure-cli/issues/27796#issuecomment-1801447309, `az --version` performs an update check, which can be slow with a poor network connection. On the other hand, `az version` doesn't make any network requests and is faster. This pr replaces `az --version` with `az version` to improve the speed of azure/login.