### PR TITLE
Mention "allow-no-subscriptions" in missing subscriptionId error

### DIFF
--- a/src/common/LoginConfig.ts
+++ b/src/common/LoginConfig.ts
@@ -99,7 +99,7 @@ export class LoginConfig {
             }
         }
         if (!this.subscriptionId && !this.allowNoSubscriptionsLogin) {
-            throw new Error("Ensure subscriptionId is supplied.");
+            throw new Error("Ensure 'subscription-id' is supplied or 'allow-no-subscriptions' is 'true'.");
         }
     }
 


### PR DESCRIPTION
"allow-no-subscriptions" is a handy option when one wants to authenticate to Entra ID, without necessarily talking with Azure RM afterwards, so I suggest to add it in the error message so it's more easily discovered by users.
While I changed this, I also switched to "subscription-id" which is the correct name for the option that users must write in their workflows