### PR TITLE
move pre cleanup to main and add pre-if and post-if

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,6 @@ branding:
   color: 'blue'
 runs:
   using: 'node20'
-  pre: 'lib/cleanup/index.js'
   main: 'lib/main/index.js'
+  post-if: (!env.AZURE_LOGIN_POST_CLEANUP || env.AZURE_LOGIN_POST_CLEANUP != 'false')
   post: 'lib/cleanup/index.js'

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import * as core from '@actions/core';
-import { setUserAgent } from './common/Utils'; 
+import { cleanupAzCLIAccounts, cleanupAzPSAccounts, setUserAgent } from './common/Utils';
 import { AzPSLogin } from './PowerShell/AzPSLogin';
 import { LoginConfig } from './common/LoginConfig';
 import { AzureCliLogin } from './Cli/AzureCliLogin';
@@ -7,6 +7,13 @@ import { AzureCliLogin } from './Cli/AzureCliLogin';
 async function main() {
     try {
         setUserAgent();
+        const preCleanup: string = process.env.AZURE_LOGIN_PRE_CLEANUP;
+        if ('true' == preCleanup) {
+            await cleanupAzCLIAccounts();
+            if (core.getInput('enable-AzPSSession').toLowerCase() === "true") {
+                await cleanupAzPSAccounts();
+            }
+        }
 
         // prepare the login configuration
         var loginConfig = new LoginConfig();


### PR DESCRIPTION
This PR is going to fix #426.

### What are in this PR
- Remove `pre` step from Azure Login Action and add the "pre cleanup" to `main` step.
- Add an env variable  `AZURE_LOGIN_PRE_CLEANUP` for checking if "cleanup before login" is necessary. By default, "cleanup before login" is **disabled**, only when  `AZURE_LOGIN_PRE_CLEANUP` is set and is "true", "cleanup before login" will be run.
- Add an env variable `AZURE_LOGIN_POST_CLEANUP` for checking if "post cleanup" is necessary. By default, "post cleanup" is **enabled**.

### Description of the issues we know about

##### 1. If Azure CLI, PowerShell or Azure PowerShell are not pre-installed on runner but installed in the steps of the workflow, an warning will be thrown in the `pre` step. E.g., "ephemeral self-hosted runners" as metioned in #426.
  - It'll be fixed in this PR since pre step will be removed.
##### 2. `pre cleanup` or `post cleanup` are not necessary for GitHub-hosted runners since they are always clean.
  - After this PR, by default, there is no `pre cleanup` in a job. 
  - `post cleanup` does no harm. But it's also OK if users set env `AZURE_LOGIN_POST_CLEANUP` to `false` to skip `post cleanup` in case of GitHub-hosted runners.
##### 3. If Azure Login Action runs multiple times in a job, there will be multiple `pre` and `post` steps.
  - After this PR, there are no `pre` steps.
  - Multiple `post cleanup` steps are not necessary. Users can set env `AZURE_LOGIN_POST_CLEANUP` to `true` for only one Azure Login Action step and set env `AZURE_LOGIN_POST_CLEANUP` to `false` for all other Azure Login Action steps.
##### 4. If there is a `if` in Azure Login Action and it doesn't match, Azure Login Action will be skipped but the `pre` step will still run.
  - It'll be fixed in this PR since pre step will be removed.
##### 5. Composite Action does not support `pre` step and will throw an warning.
  - It'll be fixed in this PR since pre step will be removed.
  - `post` step will work well.
##### 6. Local Action (checkout the aciton and run it) does not support `pre` step and will throw an warning.
  - It'll be fixed in this PR since pre step will be removed.
  - `post` step will work well.

### Reference 

- Composite Action does not support `pre` step: https://github.com/actions/runner/issues/1478
- Local Action does not support `pre` step: https://github.com/actions/typescript-action/issues/564
- Azure Login Action should not clear context during a job refer to this issue #383

### How to use 

```yaml
    - name: Azure Login
      uses: azure/login@v2
      env:
        AZURE_LOGIN_PRE_CLEANUP: false
        AZURE_LOGIN_POST_CLEANUP: false
      with:
        client-id: ${{ secrets.CLIENT_ID }}
        tenant-id: ${{ secrets.TENANT_ID }}
        subscription-id: ${{ secrets.SUBSCRIPTION_ID }}
        enable-AzPSSession: true
```
