### PR TITLE
Mention "allow-no-subscriptions" in missing subscriptionId error

### DIFF
--- a/__tests__/LoginConfig.test.ts
+++ b/__tests__/LoginConfig.test.ts
@@ -245,7 +245,7 @@ describe("LoginConfig Test", () => {
 
         let loginConfig = new LoginConfig();
         await loginConfig.initialize();
-        testValidateWithErrorMessage(loginConfig, "Ensure subscriptionId is supplied.");
+        testValidateWithErrorMessage(loginConfig, "Ensure 'subscription-id' is supplied or 'allow-no-subscriptions' is 'true'.");
     });
 
     test('validate without subscriptionId and allowNoSubscriptionsLogin=true', async () => {

--- a/src/common/LoginConfig.ts
+++ b/src/common/LoginConfig.ts
@@ -99,7 +99,7 @@ export class LoginConfig {
             }
         }
         if (!this.subscriptionId && !this.allowNoSubscriptionsLogin) {
-            throw new Error("Ensure subscriptionId is supplied.");
+            throw new Error("Ensure 'subscription-id' is supplied or 'allow-no-subscriptions' is 'true'.");
         }
     }
 


### PR DESCRIPTION
Thanks @cnotin for contributing the pr: https://github.com/Azure/login/pull/470

---
From @cnotin:
"allow-no-subscriptions" is a handy option when one wants to authenticate to Entra ID, without necessarily talking with Azure RM afterwards, so I suggest to add it in the error message so it's more easily discovered by users.
While I changed this, I also switched to "subscription-id" which is the correct name for the option that users must write in their workflows

---
Fix the CI test in this pr

---
Close https://github.com/Azure/login/pull/470

