### PR TITLE
Use `--client-id` for user-assigned managed identity authentication in Azure CLI v2.69.0 or later.

### DIFF
--- a/src/Cli/AzureCliLogin.ts
+++ b/src/Cli/AzureCliLogin.ts
@@ -31,8 +31,12 @@ export class AzureCliLogin {
 
         await this.executeAzCliCommand(["version"], true, execOptions);
         core.debug(`Azure CLI version used:\n${output}`);
-        this.azVersion = JSON.parse(output)["azure-cli"];
-
+        try {
+            this.azVersion = JSON.parse(output)["azure-cli"];
+        }
+        catch (error) {
+            core.warning("Failed to parse Azure CLI version.");
+        }
         await this.registerAzurestackEnvIfNecessary();
 
         await this.executeAzCliCommand(["cloud", "set", "-n", this.loginConfig.environment], false);

--- a/src/Cli/AzureCliLogin.ts
+++ b/src/Cli/AzureCliLogin.ts
@@ -114,7 +114,13 @@ export class AzureCliLogin {
     }
 
     async loginWithUserAssignedIdentity(args: string[]) {
-        const azcliMinorVersion = parseInt(this.azVersion.split('.')[1], 10);
+        let azcliMinorVersion = 0;
+        try {
+            azcliMinorVersion = parseInt(this.azVersion.split('.')[1], 10);
+        }
+        catch (error) {
+            core.warning("Failed to parse the minor version of Azure CLI. Assuming the version is less than 2.69.0");
+        }
         //From Azure-cli v2.69.0, `--username` is replaced with `--client-id`, `--object-id` or `--resource-id`: https://github.com/Azure/azure-cli/pull/30525
         if (azcliMinorVersion < 69) {
             args.push("--username", this.loginConfig.servicePrincipalId);


### PR DESCRIPTION
Azure CLI introduced 3 new arguments `--client-id`, `--object-id` and `--resource-id` to replace `--username` for user-assigned managed identity authentication: https://github.com/Azure/azure-cli/pull/30525.

Since `azure/login` only supports `client-id`: https://github.com/marketplace/actions/azure-login#login-with-user-assigned-managed-identity, it should map `client-id` to `--client-id` instead of `--username`.

For not introducing breaking changes, `--username` should be kept in Azure/login for Azure CLI versions before 2.69.0. But it is only valid in Azure/login@v2, once Azure CLI removes the argument `--username`, Azure/login@v1 will break for user-assigned managed identity login.

The test workflow: https://github.com/Azure/azclitools-actions-test/blob/main/.github/workflows/azure-login-mi-version-test.yml
Workflow result: https://github.com/Azure/azclitools-actions-test/actions/runs/13513290504

Close #506 