### PR TITLE
Log more claims for OIDC login

### DIFF
--- a/src/common/LoginConfig.ts
+++ b/src/common/LoginConfig.ts
@@ -87,9 +87,8 @@ export class LoginConfig {
             core.info("Federated token details:\n issuer - " + issuer + "\n subject claim - " + subjectClaim + "\n audience - " + audience + "\n job_workflow_ref - " + jobWorkflowRef);
         }
         catch (error) {
-            core.warning("Failed to parse the federated token. Missing necessary claims.");
+            core.warning(`Failed to parse the federated token. Error: ${error}`);
         }
-        
     }
 
     validate() {
@@ -120,5 +119,11 @@ async function jwtParser(federatedToken: string) {
     let tokenPayload = federatedToken.split('.')[1];
     let bufferObj = Buffer.from(tokenPayload, "base64");
     let decodedPayload = JSON.parse(bufferObj.toString("utf8"));
+    const requiredClaims = ['iss', 'sub', 'aud', 'job_workflow_ref'];
+    for (const claim of requiredClaims) {
+        if (!decodedPayload[claim]) {
+            throw new Error(`The claim '${claim}' is missing from the token payload`);
+        }
+    }
     return [decodedPayload['iss'], decodedPayload['sub'], decodedPayload['aud'], decodedPayload['job_workflow_ref']];
 }

--- a/src/common/LoginConfig.ts
+++ b/src/common/LoginConfig.ts
@@ -119,11 +119,20 @@ async function jwtParser(federatedToken: string) {
     let tokenPayload = federatedToken.split('.')[1];
     let bufferObj = Buffer.from(tokenPayload, "base64");
     let decodedPayload = JSON.parse(bufferObj.toString("utf8"));
-    const requiredClaims = ['iss', 'sub', 'aud', 'job_workflow_ref'];
+    const JWT_CLAIM_ISSUER = 'iss';
+    const JWT_CLAIM_SUBJECT = 'sub';
+    const JWT_CLAIM_AUDIENCE = 'aud';
+    const JWT_CLAIM_JOB_WORKFLOW_REF = 'job_workflow_ref';
+    const requiredClaims = [
+        JWT_CLAIM_ISSUER,
+        JWT_CLAIM_SUBJECT,
+        JWT_CLAIM_AUDIENCE,
+        JWT_CLAIM_JOB_WORKFLOW_REF
+    ];
     for (const claim of requiredClaims) {
         if (!decodedPayload[claim]) {
             throw new Error(`The claim '${claim}' is missing from the token payload`);
         }
     }
-    return [decodedPayload['iss'], decodedPayload['sub'], decodedPayload['aud'], decodedPayload['job_workflow_ref']];
-}
+    return [decodedPayload[JWT_CLAIM_ISSUER], decodedPayload[JWT_CLAIM_SUBJECT], decodedPayload[JWT_CLAIM_AUDIENCE], decodedPayload[JWT_CLAIM_JOB_WORKFLOW_REF]];   
+}   


### PR DESCRIPTION
As suggested in issue #505, adding more claim logs for OIDC login would be beneficial. This pr logs `audience` and `job_workflow_ref` in addition to `issuer` and `subject`. For details on the GitHub federated token format, refer to https://token.actions.githubusercontent.com/.well-known/openid-configuration, and https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect#understanding-the-oidc-token

Close #505