### PR TITLE
Add support for a custom az-path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,9 @@ inputs:
     description: 'The type of authentication. Supported values are SERVICE_PRINCIPAL, IDENTITY. Default value is SERVICE_PRINCIPAL'
     required: false
     default: 'SERVICE_PRINCIPAL'
+  az-path:
+    description: 'Override the location of the Azure CLI program'
+    required: false
 branding:
   icon: 'login.svg'
   color: 'blue'

--- a/src/Cli/AzureCliLogin.ts
+++ b/src/Cli/AzureCliLogin.ts
@@ -7,6 +7,7 @@ import * as io from '@actions/io';
 export class AzureCliLogin {
     loginConfig: LoginConfig;
     azPath: string;
+    azPathOverridden: boolean;
     loginOptions: ExecOptions;
     azVersion: string;
 
@@ -17,7 +18,8 @@ export class AzureCliLogin {
 
     async login() {
         core.info(`Running Azure CLI Login.`);
-        this.azPath = await io.which("az", true);
+        this.azPath = this.loginConfig.azPath;
+        this.azPathOverridden = this.loginConfig.azPathOverridden;
         core.debug(`Azure CLI path: ${this.azPath}`);
 
         let output: string = "";
@@ -159,7 +161,8 @@ export class AzureCliLogin {
         silent?: boolean,
         execOptions: any = {}) {
         execOptions.silent = !!silent;
-        await exec.exec(`"${this.azPath}"`, args, execOptions);
+        const azPath = this.azPathOverridden ? this.azPath : `"${this.azPath}`;
+        await exec.exec(azPath, args, execOptions);
     }
 }
 

--- a/src/common/LoginConfig.ts
+++ b/src/common/LoginConfig.ts
@@ -1,4 +1,5 @@
 import * as core from '@actions/core';
+import * as io from "@actions/io";
 
 export class LoginConfig {
     static readonly AUTH_TYPE_SERVICE_PRINCIPAL = "SERVICE_PRINCIPAL";
@@ -25,6 +26,8 @@ export class LoginConfig {
     enableAzPSSession: boolean;
     audience: string;
     federatedToken: string;
+    azPath: string;
+    azPathOverridden: boolean;
 
     async initialize() {
         this.environment = core.getInput("environment").toLowerCase();
@@ -41,9 +44,21 @@ export class LoginConfig {
 
         this.audience = core.getInput('audience', { required: false });
         this.federatedToken = null;
+        await this.getAzPath();
 
         this.mask(this.servicePrincipalId);
         this.mask(this.servicePrincipalSecret);
+    }
+
+    private async getAzPath(): Promise<void> {
+        this.azPath = core.getInput('az-path', { required: false });
+        if (this.azPath) {
+            this.azPathOverridden = true
+            return;
+        }
+
+        this.azPath = await io.which('az', true);
+        this.azPathOverridden = false
     }
 
     private readParametersFromCreds() {

--- a/src/common/Utils.ts
+++ b/src/common/Utils.ts
@@ -12,10 +12,19 @@ export function setUserAgent(): void {
 }
 
 export async function cleanupAzCLIAccounts(): Promise<void> {
-    let azPath = await io.which("az", true);
+    let azPath = core.getInput('az-path', { required: false });
+    let wrap = false
+    if (!azPath) {
+        azPath = await io.which('az', true);
+        wrap = true
+    }
+
     core.debug(`Azure CLI path: ${azPath}`);
     core.info("Clearing azure cli accounts from the local cache.");
-    await exec.exec(`"${azPath}"`, ["account", "clear"]);  
+    if (wrap) {
+        azPath = `"${azPath}"`;
+    }
+    await exec.exec(azPath, ["account", "clear"]);
 }
 
 export async function cleanupAzPSAccounts(): Promise<void> {


### PR DESCRIPTION
In some of our workflows we use docker containers to ensure we've got a consistent environment. We use this action to authenticate with OIDC, but this action assumes the `az` CLI is running on the GitHub actions machine.

This PR allows a custom `az` path to be specified, so that we can authenticate inside the docker container, and then run our following `az` commands in there.

For example:
```yaml
- name: Setup docker container
  run: |
    docker build . -t ci-image
    docker run --interactive --detach \
      --env ACTIONS_ID_TOKEN_REQUEST_URL=$ACTIONS_ID_TOKEN_REQUEST_URL \
      --env ACTIONS_ID_TOKEN_REQUEST_TOKEN=$ACTIONS_ID_TOKEN_REQUEST_TOKEN \
      --name ci ci-image

- name: Authenticate with Azure
  uses: azure/login@v2
  with:
    client-id: "${{ secrets.AZURE_CLIENT_ID }}"
    tenant-id: "${{ secrets.AZURE_TENANT_ID }}"
    subscription-id: "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
    az-path: "docker exec ci az"

- name: Now we can run az inside our container
  run: docker exec ci az account show
```