### PR TITLE
fix: pin 27 unpinned action(s),extract 2 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/azure-login-canary.yml
+++ b/.github/workflows/azure-login-canary.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v6
         
       - name: 'Az CLI login with subscription'
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           
@@ -41,7 +41,7 @@ jobs:
           az account show --output none
           
       - name: 'Az CLI login without subscription'
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           allow-no-subscriptions: true
@@ -50,7 +50,7 @@ jobs:
           az account show --output none
           
       - name: 'Az CLI login with subscription OIDC'
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           client-id: ${{ secrets.AZURE_CLIENTID }}
           tenant-id: ${{ secrets.AZURE_TENANTID }}
@@ -60,7 +60,7 @@ jobs:
           az account show --output none
           
       - name: 'Az CLI login without subscription OIDC'
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           client-id: ${{ secrets.AZURE_CLIENTID }}
           tenant-id: ${{ secrets.AZURE_TENANTID }}
@@ -88,4 +88,6 @@ jobs:
               echo "report=$REPORT" >> $GITHUB_OUTPUT
           - name: Post to slack
             shell: bash
-            run: curl -X POST -H 'Content-type:application/json' --data '{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":"${{steps.slack_report.outputs.report}}"}}]}' https://hooks.slack.com/services/${{SECRETS.SLACK_CHANNEL_SECRET}}
+            run: curl -X POST -H 'Content-type:application/json' --data '{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":"${{steps.slack_report.outputs.report}}"}}]}' https://hooks.slack.com/services/${SLACK_CHANNEL_SECRET}
+            env:
+              SLACK_CHANNEL_SECRET: ${{SECRETS.SLACK_CHANNEL_SECRET}}

--- a/.github/workflows/azure-login-integration-tests.yml
+++ b/.github/workflows/azure-login-integration-tests.yml
@@ -14,7 +14,7 @@ jobs:
 #     continue-on-error: true
     steps:
       - name: 'Az CLI login with subscription'
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           
@@ -23,7 +23,7 @@ jobs:
           az vm list --output none
           
       - name: 'Az CLI login without subscription'
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           allow-no-subscriptions: true
@@ -32,24 +32,24 @@ jobs:
           az account show --output none
           
       - name: 'Azure PowerShell login with subscription'
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           enable-AzPSSession: true
           
-      - uses: azure/powershell@v3
+      - uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3
         with:
           inlineScript: "(Get-AzContext).Environment.Name"
           azPSVersion: "latest"
           
       - name: 'Azure PowerShell login without subscription'
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           creds: ${{secrets.AZURE_CREDENTIALS}}
           enable-AzPSSession: true
           allow-no-subscriptions: true
         
-      - uses: azure/powershell@v3
+      - uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3
         with:
           inlineScript: "(Get-AzContext).Environment.Name"
           azPSVersion: "latest"
@@ -59,7 +59,7 @@ jobs:
 #     continue-on-error: true
     steps:
       - name: 'Az CLI login with subscription'
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           client-id: ${{ secrets.AZURE_CLIENTID }}
           tenant-id: ${{ secrets.AZURE_TENANTID }}
@@ -70,7 +70,7 @@ jobs:
           az vm list --output none
           
       - name: 'Az CLI login without subscription'
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           client-id: ${{ secrets.AZURE_CLIENTID }}
           tenant-id: ${{ secrets.AZURE_TENANTID }}
@@ -80,27 +80,27 @@ jobs:
           az account show --output none
           
       - name: 'Azure PowerShell login with subscription'
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           client-id: ${{ secrets.AZURE_CLIENTID }}
           tenant-id: ${{ secrets.AZURE_TENANTID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTIONID }} 
           enable-AzPSSession: true
           
-      - uses: azure/powershell@v3
+      - uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3
         with:
           inlineScript: "(Get-AzContext).Environment.Name"
           azPSVersion: "latest"
           
       - name: 'Azure PowerShell login without subscription'
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           client-id: ${{ secrets.AZURE_CLIENTID }}
           tenant-id: ${{ secrets.AZURE_TENANTID }}
           enable-AzPSSession: true
           allow-no-subscriptions: true
         
-      - uses: azure/powershell@v3
+      - uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3
         with:
           inlineScript: "(Get-AzContext).Environment.Name"
           azPSVersion: "latest"
@@ -126,4 +126,6 @@ jobs:
 
           - name: Post to slack
             shell: bash
-            run: curl -X POST -H 'Content-type:application/json' --data '{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":"${{steps.slack_report.outputs.report}}"}}]}' https://hooks.slack.com/services/${{SECRETS.SLACK_CHANNEL_SECRET}}
+            run: curl -X POST -H 'Content-type:application/json' --data '{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":"${{steps.slack_report.outputs.report}}"}}]}' https://hooks.slack.com/services/${SLACK_CHANNEL_SECRET}
+            env:
+              SLACK_CHANNEL_SECRET: ${{SECRETS.SLACK_CHANNEL_SECRET}}

--- a/.github/workflows/azure-login-negative.yml
+++ b/.github/workflows/azure-login-negative.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Run Azure PowerShell
       id: ps_3
       continue-on-error: true
-      uses: azure/powershell@v3
+      uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -186,7 +186,7 @@ jobs:
     - name: Run Azure PowerShell
       id: ps_8
       continue-on-error: true
-      uses: azure/powershell@v3
+      uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -216,7 +216,7 @@ jobs:
     - name: Run Azure PowerShell
       id: ps_9
       continue-on-error: true
-      uses: azure/powershell@v3
+      uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3
       with:
         azPSVersion: "latest"
         inlineScript: |

--- a/.github/workflows/azure-login-positive.yml
+++ b/.github/workflows/azure-login-positive.yml
@@ -47,7 +47,7 @@ jobs:
         az vm list --output none
 
     - name: Run Azure PowerShell
-      uses: azure/powershell@v3
+      uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -69,7 +69,7 @@ jobs:
         az account show --output none
 
     - name: Run Azure PowerShell again
-      uses: azure/powershell@v3
+      uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -92,7 +92,7 @@ jobs:
         az vm list --output none
 
     - name: Run Azure PowerShell
-      uses: azure/powershell@v3
+      uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -160,7 +160,7 @@ jobs:
         az vm list --output none
  
     - name: Run Azure PowerShell
-      uses: azure/powershell@v3
+      uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -183,7 +183,7 @@ jobs:
         az account show --output none
 
     - name: Run Azure PowerShell again
-      uses: azure/powershell@v3
+      uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -209,7 +209,7 @@ jobs:
         }
 
     - name: Run Azure PowerShell
-      uses: azure/powershell@v3
+      uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -230,7 +230,7 @@ jobs:
         az account show --output none
 
     - name: Run Azure PowerShell
-      uses: azure/powershell@v3
+      uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -309,7 +309,7 @@ jobs:
         az group list --output none
 
     - name: Run Azure PowerShell again
-      uses: azure/powershell@v3
+      uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3
       with:
         azPSVersion: "latest"
         inlineScript: |


### PR DESCRIPTION
## Summary

This PR hardens your CI/CD workflows against supply chain attacks by pinning GitHub Actions to immutable commit SHAs and extracting unsafe expressions from `run:` blocks into `env:` mappings.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | medium | `azure-login-canary.yml` | Pinned 4 action(s) to commit SHA |
| RGS-008 | high | `azure-login-canary.yml` | Extracted 1 expression(s) to env vars |
| RGS-007 | medium | `azure-login-integration-tests.yml` | Pinned 12 action(s) to commit SHA |
| RGS-008 | high | `azure-login-integration-tests.yml` | Extracted 1 expression(s) to env vars |
| RGS-007 | medium | `azure-login-negative.yml` | Pinned 3 action(s) to commit SHA |
| RGS-007 | medium | `azure-login-positive.yml` | Pinned 8 action(s) to commit SHA |




## Why this PR

I've been scanning the top 50,000 GitHub repositories for CI/CD pipeline vulnerabilities over the last 5 weeks as part of an ongoing research effort into the supply chain attack campaign that started with tj-actions in March and has escalated through multiple phases since.

You may notice that I have opened up a lot of PRs - don't take that as a negative. I've been working around the clock on this and monitoring all comms. It may take me an hour or two to get back to a comment you leave.

## How to verify

Every change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@v3` becomes `action@abc123 # v3` - original version preserved as comment
- **Expression extraction**: `${{ expr }}` in `run:` moves to `env:` block, referenced as `"${ENV_VAR}"` in the script
- No workflow logic, triggers, or permissions are modified

I've had 22 merges so far. I created a tool called [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) to assist in my research - it does mechanical, non-AI fixes to reduce hallucinations to zero and produce consistent fixes. If you would like to scan it yourself to validate my work, feel free.

Happy to answer any questions - I'm monitoring comms on every PR.

\- Chris Nyhuis ([dagecko](https://github.com/dagecko))