### PR TITLE
Pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/azure-login-canary.yml
+++ b/.github/workflows/azure-login-canary.yml
@@ -30,7 +30,7 @@ jobs:
            az --version
            
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         
       - name: 'Az CLI login with subscription'
         uses: azure/login@v3

--- a/.github/workflows/azure-login-live-tests.yml
+++ b/.github/workflows/azure-login-live-tests.yml
@@ -52,10 +52,10 @@ jobs:
 
     steps:
     - name: 'Checking out repo code'
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     - name: Set Node.js 24.x for GitHub Action
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
       with:
         node-version: 24.x
 
@@ -144,10 +144,10 @@ jobs:
 
     steps:
     - name: 'Checking out repo code'
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     - name: Set Node.js 24.x for GitHub Action
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
       with:
         node-version: 24.x
 
@@ -277,10 +277,10 @@ jobs:
     environment: Automation test
     steps:
     - name: 'Checking out repo code'
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     - name: Set Node.js 24.x for GitHub Action
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
       with:
         node-version: 24.x
       
@@ -360,10 +360,10 @@ jobs:
     steps:
 
     - name: 'Checking out repo code'
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     - name: Set Node.js 24.x for GitHub Action
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
       with:
         node-version: 24.x
 
@@ -390,7 +390,7 @@ jobs:
 
     - name: Check Last step failed
       if: steps.cli_3.outcome == 'success'
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
           script: |
             core.setFailed('Last action should fail but not. Please check it.')
@@ -407,7 +407,7 @@ jobs:
 
     - name: Check Last step failed
       if: steps.ps_3.outcome == 'success'
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
           script: |
             core.setFailed('Last action should fail but not. Please check it.')
@@ -423,10 +423,10 @@ jobs:
 
     steps:
     - name: 'Checking out repo code'
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     - name: Set Node.js 24.x for GitHub Action
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
       with:
         node-version: 24.x
 
@@ -445,7 +445,7 @@ jobs:
 
     - name: Check Last step failed
       if: steps.login_4.outcome == 'success'
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
           script: |
             core.setFailed('Last action should fail but not. Please check it.')
@@ -460,7 +460,7 @@ jobs:
 
     - name: Check Last step failed
       if: steps.login_5.outcome == 'success'
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
           script: |
             core.setFailed('Last action should fail but not. Please check it.')
@@ -474,7 +474,7 @@ jobs:
 
     - name: Check Last step failed
       if: steps.login_6.outcome == 'success'
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
           script: |
             core.setFailed('Last action should fail but not. Please check it.')
@@ -490,7 +490,7 @@ jobs:
 
     - name: Check Last step failed
       if: steps.login_7.outcome == 'success'
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
           script: |
             core.setFailed('Last action should fail but not. Please check it.')
@@ -507,7 +507,7 @@ jobs:
 
     - name: Check Last step failed
       if: steps.login_8.outcome == 'success'
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
           script: |
             core.setFailed('Last action should fail but not. Please check it.')
@@ -535,7 +535,7 @@ jobs:
 
     - name: Check Last step failed
       if: steps.ps_8.outcome == 'success'
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
           script: |
             core.setFailed('Last action should fail but not. Please check it.')
@@ -563,7 +563,7 @@ jobs:
 
     - name: Check Last step failed
       if: steps.ps_9.outcome == 'success'
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
           script: |
             core.setFailed('Last action should fail but not. Please check it.')
@@ -582,7 +582,7 @@ jobs:
 
     - name: Check Last step failed
       if: steps.login_10.outcome == 'success'
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
           script: |
             core.setFailed('Last action should fail but not. Please check it.')
@@ -599,7 +599,7 @@ jobs:
 
     - name: Check Last step failed
       if: steps.login_11.outcome == 'success'
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
           script: |
             core.setFailed('Last action should fail but not. Please check it.')
@@ -619,7 +619,7 @@ jobs:
     
     - name: Check Last step failed
       if: steps.login_12.outcome == 'success'
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
           script: |
             core.setFailed('Last action should fail but not. Please check it.')
@@ -635,7 +635,7 @@ jobs:
       
     - name: Check Last step failed
       if: steps.login_13.outcome == 'success'
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
           script: |
             core.setFailed('Last action should fail but not. Please check it.')
@@ -651,7 +651,7 @@ jobs:
 
     - name: Check Last step failed
       if: steps.login_14.outcome == 'success'
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
           script: |
             core.setFailed('Last action should fail but not. Please check it.')
@@ -666,7 +666,7 @@ jobs:
 
     - name: Check Last step failed
       if: steps.login_15.outcome == 'success'
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
           script: |
             core.setFailed('Last action should fail but not. Please check it.')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
 
     - name: 'Checking out repo code'
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     - name: Set Node.js 24.x for GitHub Action
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
       with:
         node-version: 24.x
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,18 +19,18 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@f3712979fa5f215279b101dd0a2e3bdfb4353324 # v3.37.7
       with:
         languages: javascript
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@f3712979fa5f215279b101dd0a2e3bdfb4353324 # v3.37.7
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -44,4 +44,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@f3712979fa5f215279b101dd0a2e3bdfb4353324 # v3.37.7

--- a/.github/workflows/defaultLabels.yml
+++ b/.github/workflows/defaultLabels.yml
@@ -14,7 +14,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
           
-      - uses: actions/stale@v8
+      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
         name: Setting issue as idle
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -25,7 +25,7 @@ jobs:
           operations-per-run: 100
           exempt-issue-labels: 'backlog'
           
-      - uses: actions/stale@v8
+      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
         name: Setting PR as idle
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -35,7 +35,7 @@ jobs:
           days-before-close: -1
           operations-per-run: 100
 
-      - uses: actions/stale@v8
+      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
         name: Close issue with no feedback for 20 days
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 24.x
       - name: Run Markdownlint


### PR DESCRIPTION
## Summary
Pins externally-owned GitHub Actions to immutable commit SHAs to reduce supply-chain risk.

## Changes
Third-party actions were referenced by movable major tags (e.g. `actions/checkout@v6`). A tag can be repointed by the upstream owner, or by an attacker who compromises that action's repository, silently running new code in our CI with our permissions. This is the class of attack seen with `tj-actions` in 2025.

Each externally-owned action is now pinned to the commit SHA its tag currently resolves to, with the human-readable version kept in a trailing comment:
- `actions/checkout` → v6.1.0
- `actions/setup-node` → v6.5.0
- `actions/github-script` → v7.1.0
- `actions/stale` → v8.0.0
- `github/codeql-action` (init/autobuild/analyze) → v3.37.7

## Maintenance
Dependabot is already configured for the `github-actions` ecosystem. It understands SHA pins and raises update PRs that bump both the SHA and the trailing version comment together, so the pins stay current without manual tracking and do not drift from the comment.

## Deliberately not pinned
`azure/login` and `azure/powershell` stay on `@v3`. These are our own actions used as test and provisioning tooling; the canary and integration suites exist to validate the current `v3`, so pinning them to a SHA would freeze what the tests exercise and cause drift from the released major. The supply-chain threat model does not apply to our own action's CI.
