### PR TITLE
Harden Dependabot config for the CommonJS ncc build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,20 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
+    labels: ["dependencies"]
     groups:
       dev-dependencies:
         dependency-type: "development"
+        update-types: ["minor", "patch"]
+    ignore:
+      # ts-jest currently supports "typescript >=4.3 <7", so cap TypeScript
+      # below 7 (the native compiler rewrite) until ts-jest supports it.
+      - dependency-name: "typescript"
+        versions: [">=7"]
+      # @actions/io 3.x is ESM-only, which breaks the CommonJS ncc build.
+      # Stay on 2.x (CommonJS, Node 24 support) until the action moves to ESM.
+      - dependency-name: "@actions/io"
+        versions: [">=3"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
- Ignore typescript >=7: the native compiler rewrite. ts-jest declares a peer of "typescript >=4.3 <7", so TS 7 fails npm install with an ERESOLVE conflict.
- Ignore @actions/io >=3: 3.x is ESM-only, which the CommonJS ncc bundle cannot require(). Stay on 2.x (CommonJS, Node 24 support) until the action moves to ESM.
- Limit the dev-dependencies group to minor and patch updates so a breaking major no longer poisons the whole grouped PR; majors now arrive as isolated, reviewable PRs.
- Label npm dependency PRs with "dependencies".

Production dependencies are intentionally left ungrouped so each runtime bump is reviewed individually and one breaking major cannot block the others.