### PR TITLE
Cap @actions/exec and @actions/core below the ESM-only 3.x majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,9 +15,15 @@ updates:
       # below 7 (the native compiler rewrite) until ts-jest supports it.
       - dependency-name: "typescript"
         versions: [">=7"]
-      # @actions/io 3.x is ESM-only, which breaks the CommonJS ncc build.
-      # Stay on 2.x (CommonJS, Node 24 support) until the action moves to ESM.
+      # @actions/io, @actions/exec and @actions/core 3.x are ESM-only
+      # (package.json "type": "module"), which the CommonJS ncc bundle cannot
+      # require(). @actions/http-client 3.x is still CommonJS, so it is not
+      # capped. Stay on 2.x for the ESM packages until the action migrates to ESM.
       - dependency-name: "@actions/io"
+        versions: [">=3"]
+      - dependency-name: "@actions/exec"
+        versions: [">=3"]
+      - dependency-name: "@actions/core"
         versions: [">=3"]
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
@actions/exec 3.0.0 and @actions/core 3.0.1 ship as ESM-only (package.json "type": "module"), which the CommonJS ncc bundle cannot require() (see the failing bumps in #623 and #624, same failure mode as the already-capped @actions/io). Extend the existing ESM cap to these two packages so Dependabot stays on their 2.x (CommonJS) line until the action migrates to ESM. @actions/http-client 3.x remains CommonJS and is intentionally not capped.