### PR TITLE
Add the ability to prevent the masking of clientId

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   - [Security Updates](#security-updates)
   - [Input Parameters](#input-parameters)
     - [`client-id`](#client-id)
+    - [`mask-client-id`](#mask-client-id)
     - [`subscription-id`](#subscription-id)
     - [`tenant-id`](#tenant-id)
     - [`creds`](#creds)
@@ -144,6 +145,7 @@ Customers using v1 should migrate to v3. End-of-life releases no longer receive 
 |allow-no-subscriptions|false|boolean|false|if login without subscription is allowed|
 |audience|false|string|api://AzureADTokenExchange|the audience to get the JWT ID token from GitHub OIDC provider|
 |auth-type|false|string|SERVICE_PRINCIPAL|the auth type|
+|mask-client-id|false|boolean|true|if the `client-id` value is masked in workflow logs|
 
 ### `client-id`
 
@@ -156,7 +158,28 @@ It's better to create a GitHub Action secret for this parameter when using it. R
 Refer to [Login With OpenID Connect (OIDC)](#login-with-openid-connect-oidc-recommended) and [Login With User-assigned Managed Identity](#login-with-user-assigned-managed-identity) for its usage.
 
 > [!NOTE]
-> The action registers the `client-id` value as a secret (via `core.setSecret`) so it is masked in workflow logs. Some enterprises treat the client ID as sensitive, and masking also prevents it from being printed accidentally, which matters in public repositories. `tenant-id` and `subscription-id` are not masked.
+> By default the action registers the `client-id` value as a secret (via `core.setSecret`) so it is masked in workflow logs. Some enterprises treat the client ID as sensitive, and masking also prevents it from being printed accidentally, which matters in public repositories. `tenant-id` and `subscription-id` are not masked. Set [`mask-client-id`](#mask-client-id) to `false` to opt out of the masking.
+
+### `mask-client-id`
+
+The input parameter `mask-client-id` controls whether the login client id is registered as a secret and masked in the workflow logs. It defaults to `true`.
+
+Set it to `false` when the client id is not treated as sensitive and masking gets in the way, for example when the same value appears in log output or command results that you need to read.
+
+The client-id is effectively a username: it is low sensitivity on its own, and only useful to an attacker who already holds the client secret or certificate. Disabling masking is therefore reasonable when the value is treated as configuration rather than as a secret.
+
+```yaml
+  - name: Azure login
+    uses: azure/login@v3
+    with:
+      tenant-id: ${{ vars.AZURE_TENANT_ID }}
+      subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      client-id: ${{ vars.AZURE_CLIENT_ID }}
+      mask-client-id: false
+```
+
+> [!NOTE]
+> The value is only unmasked when it is not a GitHub Action secret. A value passed from `${{ secrets.* }}` is still masked by GitHub itself, regardless of this input.
 
 ### `subscription-id`
 

--- a/__tests__/LoginConfig.test.ts
+++ b/__tests__/LoginConfig.test.ts
@@ -1,4 +1,5 @@
 import { LoginConfig } from "../src/common/LoginConfig";
+import * as core from "@actions/core";
 
 describe("LoginConfig Test", () => {
 
@@ -40,6 +41,10 @@ describe("LoginConfig Test", () => {
 
     beforeEach(() => {
         cleanEnv();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
     });
 
     test('initialize with creds, lack of clientId', async () => {
@@ -173,6 +178,137 @@ describe("LoginConfig Test", () => {
         expect(loginConfig.servicePrincipalSecret).toBeNull();
         expect(loginConfig.tenantId).toBe("tenant-id-aa");
         expect(loginConfig.subscriptionId).toBe("subscription-id-aa");
+    });
+
+    test('initialize with mask-client-id=true', async () => {
+        const setSecretSpy = jest.spyOn(core, 'setSecret').mockImplementation(() => {});
+
+        setEnv('environment', 'azureusgovernment');
+        setEnv('enable-AzPSSession', 'false');
+        setEnv('allow-no-subscriptions', 'true');
+        setEnv('auth-type', 'SERVICE_PRINCIPAL');
+        setEnv('tenant-id', 'tenant-id');
+        setEnv('subscription-id', 'subscription-id');
+        setEnv('client-id', 'client-id');
+        setEnv('mask-client-id', 'true');
+
+        let loginConfig = new LoginConfig();
+        await loginConfig.initialize();
+        expect(loginConfig.maskClientId).toBeTruthy();
+        expect(loginConfig.servicePrincipalId).toBe("client-id");
+        expect(setSecretSpy).toHaveBeenCalledWith("client-id");
+    });
+
+
+    test('initialize with creds and mask-client-id=true', async () => {
+        const setSecretSpy = jest.spyOn(core, 'setSecret').mockImplementation(() => {});
+
+        setEnv('environment', 'azureusgovernment');
+        setEnv('enable-AzPSSession', 'false');
+        setEnv('allow-no-subscriptions', 'true');
+        setEnv('auth-type', 'SERVICE_PRINCIPAL');
+        setEnv('mask-client-id', 'true');
+
+        let creds = {
+            'clientId': 'client-id',
+            'clientSecret': 'client-secret',
+            'tenantId': 'tenant-id',
+            'subscriptionId': 'subscription-id'
+        }
+        setEnv('creds', JSON.stringify(creds));
+
+        let loginConfig = new LoginConfig();
+        await loginConfig.initialize();
+        expect(loginConfig.maskClientId).toBeTruthy();
+        expect(loginConfig.servicePrincipalId).toBe("client-id");
+        expect(setSecretSpy).toHaveBeenCalledWith("client-id");
+        expect(setSecretSpy).toHaveBeenCalledWith("client-secret");
+    });
+
+    test('initialize with mask-client-id=false', async () => {
+        const setSecretSpy = jest.spyOn(core, 'setSecret').mockImplementation(() => {});
+
+        setEnv('environment', 'azureusgovernment');
+        setEnv('enable-AzPSSession', 'false');
+        setEnv('allow-no-subscriptions', 'true');
+        setEnv('auth-type', 'SERVICE_PRINCIPAL');
+        setEnv('tenant-id', 'tenant-id');
+        setEnv('subscription-id', 'subscription-id');
+        setEnv('client-id', 'client-id');
+        setEnv('mask-client-id', 'false');
+
+        let loginConfig = new LoginConfig();
+        await loginConfig.initialize();
+        expect(loginConfig.maskClientId).toBeFalsy();
+        expect(loginConfig.servicePrincipalId).toBe("client-id");
+        expect(setSecretSpy).not.toHaveBeenCalledWith("client-id");
+    });
+
+    test('initialize with creds and mask-client-id=false', async () => {
+        const setSecretSpy = jest.spyOn(core, 'setSecret').mockImplementation(() => {});
+
+        setEnv('environment', 'azureusgovernment');
+        setEnv('enable-AzPSSession', 'false');
+        setEnv('allow-no-subscriptions', 'true');
+        setEnv('auth-type', 'SERVICE_PRINCIPAL');
+        setEnv('mask-client-id', 'false');
+
+        let creds = {
+            'clientId': 'client-id',
+            'clientSecret': 'client-secret',
+            'tenantId': 'tenant-id',
+            'subscriptionId': 'subscription-id'
+        }
+        setEnv('creds', JSON.stringify(creds));
+
+        let loginConfig = new LoginConfig();
+        await loginConfig.initialize();
+        expect(loginConfig.maskClientId).toBeFalsy();
+        expect(loginConfig.servicePrincipalId).toBe("client-id");
+        expect(setSecretSpy).not.toHaveBeenCalledWith("client-id");
+        expect(setSecretSpy).toHaveBeenCalledWith("client-secret");
+    });
+
+    test('initialize without mask-client-id', async () => {
+        const setSecretSpy = jest.spyOn(core, 'setSecret').mockImplementation(() => {});
+
+        setEnv('environment', 'azureusgovernment');
+        setEnv('enable-AzPSSession', 'false');
+        setEnv('allow-no-subscriptions', 'true');
+        setEnv('auth-type', 'SERVICE_PRINCIPAL');
+        setEnv('tenant-id', 'tenant-id');
+        setEnv('subscription-id', 'subscription-id');
+        setEnv('client-id', 'client-id');
+
+        let loginConfig = new LoginConfig();
+        await loginConfig.initialize();
+        expect(loginConfig.maskClientId).toBeTruthy();
+        expect(loginConfig.servicePrincipalId).toBe("client-id");
+        expect(setSecretSpy).toHaveBeenCalledWith("client-id");
+    });
+
+    test('initialize with creds and without mask-client-id', async () => {
+        const setSecretSpy = jest.spyOn(core, 'setSecret').mockImplementation(() => {});
+
+        setEnv('environment', 'azureusgovernment');
+        setEnv('enable-AzPSSession', 'false');
+        setEnv('allow-no-subscriptions', 'true');
+        setEnv('auth-type', 'SERVICE_PRINCIPAL');
+
+        let creds = {
+            'clientId': 'client-id',
+            'clientSecret': 'client-secret',
+            'tenantId': 'tenant-id',
+            'subscriptionId': 'subscription-id'
+        }
+        setEnv('creds', JSON.stringify(creds));
+
+        let loginConfig = new LoginConfig();
+        await loginConfig.initialize();
+        expect(loginConfig.maskClientId).toBeTruthy();
+        expect(loginConfig.servicePrincipalId).toBe("client-id");
+        expect(setSecretSpy).toHaveBeenCalledWith("client-id");
+        expect(setSecretSpy).toHaveBeenCalledWith("client-secret");
     });
 
     test('validate with wrong environment', async () => {

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: 'The type of authentication. Supported values are SERVICE_PRINCIPAL, IDENTITY. Default value is SERVICE_PRINCIPAL'
     required: false
     default: 'SERVICE_PRINCIPAL'
+  mask-client-id:
+    description: 'Set this value to false to stop registering the client-id as a secret, so it is not masked in workflow logs'
+    required: false
+    default: true
 branding:
   icon: 'login.svg'
   color: 'blue'

--- a/src/common/LoginConfig.ts
+++ b/src/common/LoginConfig.ts
@@ -25,6 +25,7 @@ export class LoginConfig {
     enableAzPSSession: boolean;
     audience: string;
     federatedToken: string;
+    maskClientId: boolean;
 
     async initialize() {
         this.environment = core.getInput("environment").toLowerCase();
@@ -42,7 +43,10 @@ export class LoginConfig {
         this.audience = core.getInput('audience', { required: false });
         this.federatedToken = null;
 
-        this.mask(this.servicePrincipalId);
+        this.maskClientId = core.getInput('mask-client-id').toLowerCase() !== "false";
+        if (this.maskClientId) {
+            this.mask(this.servicePrincipalId);
+        }
         this.mask(this.servicePrincipalSecret);
     }
 


### PR DESCRIPTION
## What changed
mask-client-id, a new optional boolean input defaulting to true:

```yaml
- uses: azure/login@v3
  with:
    client-id: ${{ vars.AZURE_CLIENT_ID }}
    tenant-id: ${{ vars.AZURE_TENANT_ID }}
    subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
    mask-client-id: false   # default: true
```

- `action.yml` - declares the input with `default: true`
- `src/common/LoginConfig.ts` - `LoginConfig` gains a `maskClientId` field and the existing `this.mask(this.servicePrincipalId)` call is now gated on it.
- `README.md` - input table row, a `mask-client-id` section, and the existing `client-id` masking note now points at the opt-out.
- `__tests__/LoginConfig.test.ts` - three cases covering the input set to `true`, set to `false`, and absent.

## Scope and default behaviour

Existing workflows are unaffected. The input defaults to `true` and every current caller keeps masking the client ID.
Only the client ID/service principal ID is in scope. servicePrincipalSecret and the OIDC federated token are still masked unconditionally.
The gate applies to the client ID from either source - the `client-id` input or `clientId` inside `creds` - since both land in the same field.
A value passed from `${{ secrets.* }}` is still masked by Actions itself regardless of this input. Opting out only has a visible effect for values that are not repository secrets, which is the case this is aimed at.

## Note for reviewers
The input is parsed as "anything other than an explicit `false` means mask":
```ts
this.maskClientId = core.getInput('mask-client-id').toLowerCase() !== "false";
```
The other boolean inputs in `LoginConfig` use `=== "true",` which resolves to false when the input is absent. That is fine for `enable-AzPSSession` and` allow-no-subscriptions`, but for a masking flag it fails in the unsafe direction - a missing input would silently stop masking. Inverting the comparison keeps a missing or malformed value on the masked path. 

Happy to switch to `core.getBooleanInput` or to match the surrounding style instead if you would prefer consistency here.