### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,5 @@ updates:
     groups:
       github-actions:
         patterns: ["*"]
+    cooldown:
+      default-days: 7

--- a/.github/workflows/azure-login-canary.yml
+++ b/.github/workflows/azure-login-canary.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         
       - name: 'Az CLI login with subscription'
-        uses: azure/login@v3
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           
@@ -41,7 +41,7 @@ jobs:
           az account show --output none
           
       - name: 'Az CLI login without subscription'
-        uses: azure/login@v3
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           allow-no-subscriptions: true
@@ -50,7 +50,7 @@ jobs:
           az account show --output none
           
       - name: 'Az CLI login with subscription OIDC'
-        uses: azure/login@v3
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           client-id: ${{ secrets.AZURE_CLIENTID }}
           tenant-id: ${{ secrets.AZURE_TENANTID }}
@@ -60,7 +60,7 @@ jobs:
           az account show --output none
           
       - name: 'Az CLI login without subscription OIDC'
-        uses: azure/login@v3
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           client-id: ${{ secrets.AZURE_CLIENTID }}
           tenant-id: ${{ secrets.AZURE_TENANTID }}

--- a/.github/workflows/azure-login-integration-tests.yml
+++ b/.github/workflows/azure-login-integration-tests.yml
@@ -14,7 +14,7 @@ jobs:
 #     continue-on-error: true
     steps:
       - name: 'Az CLI login with subscription'
-        uses: azure/login@v3
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           
@@ -23,7 +23,7 @@ jobs:
           az vm list --output none
           
       - name: 'Az CLI login without subscription'
-        uses: azure/login@v3
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           allow-no-subscriptions: true
@@ -32,24 +32,24 @@ jobs:
           az account show --output none
           
       - name: 'Azure PowerShell login with subscription'
-        uses: azure/login@v3
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           enable-AzPSSession: true
           
-      - uses: azure/powershell@v3
+      - uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3.0.0
         with:
           inlineScript: "(Get-AzContext).Environment.Name"
           azPSVersion: "latest"
           
       - name: 'Azure PowerShell login without subscription'
-        uses: azure/login@v3
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           creds: ${{secrets.AZURE_CREDENTIALS}}
           enable-AzPSSession: true
           allow-no-subscriptions: true
         
-      - uses: azure/powershell@v3
+      - uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3.0.0
         with:
           inlineScript: "(Get-AzContext).Environment.Name"
           azPSVersion: "latest"
@@ -59,7 +59,7 @@ jobs:
 #     continue-on-error: true
     steps:
       - name: 'Az CLI login with subscription'
-        uses: azure/login@v3
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           client-id: ${{ secrets.AZURE_CLIENTID }}
           tenant-id: ${{ secrets.AZURE_TENANTID }}
@@ -70,7 +70,7 @@ jobs:
           az vm list --output none
           
       - name: 'Az CLI login without subscription'
-        uses: azure/login@v3
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           client-id: ${{ secrets.AZURE_CLIENTID }}
           tenant-id: ${{ secrets.AZURE_TENANTID }}
@@ -80,27 +80,27 @@ jobs:
           az account show --output none
           
       - name: 'Azure PowerShell login with subscription'
-        uses: azure/login@v3
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           client-id: ${{ secrets.AZURE_CLIENTID }}
           tenant-id: ${{ secrets.AZURE_TENANTID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTIONID }} 
           enable-AzPSSession: true
           
-      - uses: azure/powershell@v3
+      - uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3.0.0
         with:
           inlineScript: "(Get-AzContext).Environment.Name"
           azPSVersion: "latest"
           
       - name: 'Azure PowerShell login without subscription'
-        uses: azure/login@v3
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           client-id: ${{ secrets.AZURE_CLIENTID }}
           tenant-id: ${{ secrets.AZURE_TENANTID }}
           enable-AzPSSession: true
           allow-no-subscriptions: true
         
-      - uses: azure/powershell@v3
+      - uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3.0.0
         with:
           inlineScript: "(Get-AzContext).Environment.Name"
           azPSVersion: "latest"

--- a/.github/workflows/azure-login-live-tests.yml
+++ b/.github/workflows/azure-login-live-tests.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Azure login (provisioning)
-      uses: azure/login@v3
+      uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
       with:
         creds: ${{ secrets.PROVISION_CREDS }}
     - name: Create resource group
@@ -83,7 +83,7 @@ jobs:
         az group show --name "${{ env.RG_POSITIVE }}" --output none
 
     - name: Run Azure PowerShell
-      uses: azure/powershell@v3
+      uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3.0.0
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -105,7 +105,7 @@ jobs:
         az account show --output none
 
     - name: Run Azure PowerShell again
-      uses: azure/powershell@v3
+      uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3.0.0
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -127,7 +127,7 @@ jobs:
         az group show --name "${{ env.RG_POSITIVE }}" --output none
 
     - name: Run Azure PowerShell
-      uses: azure/powershell@v3
+      uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3.0.0
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -194,7 +194,7 @@ jobs:
         az group show --name "${{ env.RG_POSITIVE }}" --output none
  
     - name: Run Azure PowerShell
-      uses: azure/powershell@v3
+      uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3.0.0
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -217,7 +217,7 @@ jobs:
         az account show --output none
 
     - name: Run Azure PowerShell again
-      uses: azure/powershell@v3
+      uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3.0.0
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -243,7 +243,7 @@ jobs:
         }
 
     - name: Run Azure PowerShell
-      uses: azure/powershell@v3
+      uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3.0.0
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -264,7 +264,7 @@ jobs:
         az account show --output none
 
     - name: Run Azure PowerShell
-      uses: azure/powershell@v3
+      uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3.0.0
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -344,7 +344,7 @@ jobs:
         az group list --output none
 
     - name: Run Azure PowerShell again
-      uses: azure/powershell@v3
+      uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3.0.0
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -401,7 +401,7 @@ jobs:
     - name: Run Azure PowerShell
       id: ps_3
       continue-on-error: true
-      uses: azure/powershell@v3
+      uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3.0.0
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -529,7 +529,7 @@ jobs:
     - name: Run Azure PowerShell
       id: ps_8
       continue-on-error: true
-      uses: azure/powershell@v3
+      uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3.0.0
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -557,7 +557,7 @@ jobs:
     - name: Run Azure PowerShell
       id: ps_9
       continue-on-error: true
-      uses: azure/powershell@v3
+      uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3.0.0
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -686,7 +686,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Azure login (provisioning)
-      uses: azure/login@v3
+      uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
       with:
         creds: ${{ secrets.PROVISION_CREDS }}
     - name: Delete resource group

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
             *) echo "::error::ref '$REF' not permitted for release (allowed: master, or a hotfix/* branch based on the latest release tag for a back-major release)"; exit 1 ;;
           esac
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.ref }}   # master for the current major; a hotfix/* branch for a back-major release
           fetch-depth: 0
@@ -94,7 +94,7 @@ jobs:
           ver=$(grep "using:" action.yml | grep -oE "node[0-9]+" | grep -oE "[0-9]+" | head -1)
           echo "version=$ver" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ steps.node.outputs.version }}   # matches action.yml runs.using
           cache: npm

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -57,7 +57,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
           fetch-tags: true


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
