### PR TITLE
Automate release tagging via deploy key + self-pin bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,8 @@ updates:
         patterns: ["*"]
     cooldown:
       default-days: 7
+    ignore:
+      # azure/login self-references are pinned by the release workflow
+      # (open-selfpin-pr job), so exclude them from Dependabot to avoid
+      # duplicate bump PRs.
+      - dependency-name: "azure/login"

--- a/.github/workflows/deploy-key-rotation-reminder.yml
+++ b/.github/workflows/deploy-key-rotation-reminder.yml
@@ -19,7 +19,7 @@ jobs:
           REPO: ${{ github.repository }}
           TITLE: 'Rotate RELEASE_DEPLOY_KEY (routine 6-month cadence)'
         run: |
-          existing=$(gh issue list --repo "$REPO" --state open --search "$TITLE in:title" --json number --jq 'length')
+          existing=$(gh issue list --repo "$REPO" --state open --limit 200 --json title --jq '[.[] | select(.title==env.TITLE)] | length')
           if [ "$existing" -gt 0 ]; then
             echo "An open rotation reminder issue already exists; skipping."
             exit 0

--- a/.github/workflows/deploy-key-rotation-reminder.yml
+++ b/.github/workflows/deploy-key-rotation-reminder.yml
@@ -1,0 +1,35 @@
+name: 'Scheduled: Deploy Key Rotation Reminder'
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 09:00 UTC on the 1st of January and July (routine 6-month cadence).
+    - cron: '0 9 1 1,7 *'
+
+permissions:
+  issues: write
+
+jobs:
+  remind:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open rotation reminder issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TITLE: 'Rotate RELEASE_DEPLOY_KEY (routine 6-month cadence)'
+        run: |
+          existing=$(gh issue list --repo "$REPO" --state open --search "$TITLE in:title" --json number --jq 'length')
+          if [ "$existing" -gt 0 ]; then
+            echo "An open rotation reminder issue already exists; skipping."
+            exit 0
+          fi
+          gh issue create --repo "$REPO" --title "$TITLE" --body 'Routine scheduled reminder to rotate the release deploy key (`RELEASE_DEPLOY_KEY`, on the `release` environment). This is a standard 6-month rotation, not an indication of any incident.
+
+          Rotation steps (requires repo admin; add the new key before removing the old one so there is no release downtime):
+
+          1. Generate a new SSH keypair with an empty passphrase.
+          2. Add the new public key as a **write** deploy key.
+          3. Update the `RELEASE_DEPLOY_KEY` environment secret with the new private key.
+          4. Delete the previous deploy key.
+          5. Close this issue.'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,7 @@ jobs:
 
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
           ref: ${{ inputs.ref }}   # master for the current major; a hotfix/* branch for a back-major release
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
           ref: ${{ inputs.ref }}   # master for the current major; a hotfix/* branch for a back-major release
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,3 +144,42 @@ jobs:
           gh release create "$V" \
             --title "Azure Login Action $V" \
             --generate-notes
+
+  open-selfpin-pr:
+    needs: release
+    if: ${{ inputs.ref == 'master' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: master
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Bump azure/login self-references and open PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          V: ${{ inputs.version }}
+        run: |
+          SHA=$(git rev-parse "refs/tags/$V^{commit}")
+          for f in .github/workflows/*.yml .github/workflows/*.yaml; do
+            [ -e "$f" ] || continue
+            sed -i -E "s|(uses:[[:space:]]+azure/login@)[^[:space:]]+.*|\1${SHA} # ${V}|" "$f"
+          done
+          if git diff --quiet; then
+            echo "No azure/login self-references to update."
+            exit 0
+          fi
+          BRANCH="chore/pin-azure-login-$V"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git commit .github/workflows -m "chore: pin azure/login self-references to $V"
+          git push --force-with-lease --set-upstream origin "$BRANCH"
+          gh pr create --base master --head "$BRANCH" \
+            --title "Pin azure/login self-references to $V" \
+            --body "Automated post-release update: repoints \`azure/login@…\` in workflow files to the built release commit \`$SHA\` (\`$V\`)." \
+            || echo "PR for $BRANCH may already exist; skipping create."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,8 +111,14 @@ jobs:
 
       - name: Verify build produced the action entry points
         run: |
-          test -f lib/main/index.js && test -f lib/cleanup/index.js \
-            || { echo "::error::build did not produce lib/main/index.js and lib/cleanup/index.js; refusing to create a release"; exit 1; }
+          main_path=$(grep -oE "main:[[:space:]]*'[^']+'" action.yml | grep -oE "'[^']+'" | tr -d "'" | head -1)
+          post_path=$(grep -oE "post:[[:space:]]*'[^']+'" action.yml | grep -oE "'[^']+'" | tr -d "'" | head -1)
+          if [ -z "$main_path" ] || [ -z "$post_path" ]; then
+            echo "::error::could not read main/post entry points from action.yml"; exit 1
+          fi
+          if [ ! -f "$main_path" ] || [ ! -f "$post_path" ]; then
+            echo "::error::build did not produce $main_path and $post_path (from action.yml); refusing to create a release"; exit 1
+          fi
 
       - name: Create release branch with built lib
         env:
@@ -158,24 +164,32 @@ jobs:
           fi
           echo "Release notes start tag: ${PREV:-<none, first release>}"
 
+          # Build the notes-start-tag argument as an array so an empty PREV (first
+          # release) appends nothing, and a value is passed as a single argument.
+          notes_args=(--generate-notes)
+          if [[ -n "$PREV" ]]; then
+            notes_args+=(--notes-start-tag "$PREV")
+          fi
+
           # No --latest flag: GitHub automatically marks the highest-version
           # release as "Latest", so a back-major release (e.g. a v2 hotfix) does
           # not steal the badge from the current major.
           gh release create "$V" \
             --title "Azure Login Action $V" \
-            --generate-notes \
-            ${PREV:+--notes-start-tag "$PREV"}
+            "${notes_args[@]}"
 
   open-selfpin-pr:
     needs: release
     if: ${{ inputs.ref == 'master' }}
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       pull-requests: write
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
           ref: master
           fetch-depth: 0
           fetch-tags: true
@@ -186,6 +200,8 @@ jobs:
           V: ${{ inputs.version }}
         run: |
           SHA=$(git rev-parse "refs/tags/$V^{commit}")
+          # Rewrite only azure/login self-references. The match starts at "uses:",
+          # so leading indentation is preserved and other actions are left untouched.
           for f in .github/workflows/*.yml .github/workflows/*.yaml; do
             [ -e "$f" ] || continue
             sed -i -E "s|(uses:[[:space:]]+azure/login@)[^[:space:]]+.*|\1${SHA} # ${V}|" "$f"
@@ -195,11 +211,14 @@ jobs:
             exit 0
           fi
           BRANCH="chore/pin-azure-login-$V"
-          git config user.name  "github-actions[bot]"
+          git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -B "$BRANCH"
           git commit .github/workflows -m "chore: pin azure/login self-references to $V"
-          git push --force-with-lease --set-upstream origin "$BRANCH"
+          # Force-push: this version-specific bot branch is safe to overwrite if a
+          # prior run left it behind, and there is no other writer to protect.
+          git push --force --set-upstream origin "$BRANCH"
+          # Tolerate an existing PR for this branch (e.g. on a re-run) without failing.
           gh pr create --base master --head "$BRANCH" \
             --title "Pin azure/login self-references to $V" \
             --body "Automated post-release update: repoints \`azure/login@…\` in workflow files to the built release commit \`$SHA\` (\`$V\`)." \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ on:
         description: "Branch to release from. Use master for the current major (v3). For a back-major release (e.g. v2), branch a hotfix off the latest release tag (git checkout -b hotfix/v2.3.2 v2.3.1) and pass that hotfix/* branch."
         required: false
         default: master
+      previous_version:
+        description: "Optional: start tag for release notes (e.g. v3.0.1). Auto-detected from the previous semver tag if left blank."
+        required: false
 
 permissions:
   contents: write   # push branch/tag, force-move major tag, create the Release
@@ -137,13 +140,26 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           V: ${{ inputs.version }}
+          PREV_INPUT: ${{ inputs.previous_version }}
         run: |
+          # Pin the release-notes start tag so --generate-notes diffs against the
+          # correct previous release. Without this, GitHub auto-selects the "previous
+          # tag" and can pick the wrong one (e.g. the floating major tag v3), which
+          # dumps the entire history into the notes.
+          PREV="$PREV_INPUT"
+          if [[ -z "$PREV" ]]; then
+            # Previous X.Y.Z tag: sort semver, exclude floating major tags (v3) and $V itself.
+            PREV=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | awk -v v="$V" '$0==v{print prev} {prev=$0}')
+          fi
+          echo "Release notes start tag: ${PREV:-<none, first release>}"
+
           # No --latest flag: GitHub automatically marks the highest-version
           # release as "Latest", so a back-major release (e.g. a v2 hotfix) does
           # not steal the badge from the current major.
           gh release create "$V" \
             --title "Azure Login Action $V" \
-            --generate-notes
+            --generate-notes \
+            ${PREV:+--notes-start-tag "$PREV"}
 
   open-selfpin-pr:
     needs: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,11 @@ jobs:
           npm run build
           npm test
 
+      - name: Verify build produced the action entry points
+        run: |
+          test -f lib/main/index.js && test -f lib/cleanup/index.js \
+            || { echo "::error::build did not produce lib/main/index.js and lib/cleanup/index.js; refusing to create a release"; exit 1; }
+
       - name: Create release branch with built lib
         env:
           V: ${{ inputs.version }}

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -59,6 +59,7 @@ jobs:
 
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
           fetch-depth: 0
           fetch-tags: true
 

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -59,6 +59,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
           fetch-depth: 0
           fetch-tags: true
 

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -112,12 +112,14 @@ jobs:
   open-selfpin-pr:
     needs: rollback
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       pull-requests: write
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
           ref: master
           fetch-depth: 0
           fetch-tags: true
@@ -130,6 +132,7 @@ jobs:
           TARGET_MAJOR="${V%%.*}"   # v3.0.1 -> v3
           # Only touch master's pins if they track the same major we are rolling back;
           # a back-major (e.g. v2) rollback must not repoint master's current-major pins.
+          # CURRENT_MAJOR reads the "# vN" suffix on the first pinned self-reference.
           CURRENT_MAJOR=$(grep -rhoE 'uses:[[:space:]]+azure/login@[0-9a-f]+[[:space:]]*#[[:space:]]*v[0-9]+' .github/workflows | head -1 | grep -oE 'v[0-9]+$')
           if [ -z "$CURRENT_MAJOR" ]; then
             echo "No pinned azure/login self-references on master; nothing to roll back."
@@ -140,6 +143,8 @@ jobs:
             exit 0
           fi
           SHA=$(git rev-parse "refs/tags/$V^{commit}")
+          # Rewrite only azure/login self-references. The match starts at "uses:",
+          # so leading indentation is preserved and other actions are left untouched.
           for f in .github/workflows/*.yml .github/workflows/*.yaml; do
             [ -e "$f" ] || continue
             sed -i -E "s|(uses:[[:space:]]+azure/login@)[^[:space:]]+.*|\1${SHA} # ${V}|" "$f"
@@ -149,11 +154,14 @@ jobs:
             exit 0
           fi
           BRANCH="chore/rollback-azure-login-$V"
-          git config user.name  "github-actions[bot]"
+          git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -B "$BRANCH"
           git commit .github/workflows -m "chore: roll back azure/login self-references to $V"
-          git push --force-with-lease --set-upstream origin "$BRANCH"
+          # Force-push: this version-specific bot branch is safe to overwrite if a
+          # prior run left it behind, and there is no other writer to protect.
+          git push --force --set-upstream origin "$BRANCH"
+          # Tolerate an existing PR for this branch (e.g. on a re-run) without failing.
           gh pr create --base master --head "$BRANCH" \
             --title "Roll back azure/login self-references to $V" \
             --body "Automated post-rollback update: repoints \`azure/login@…\` in workflow files to the rolled-back release commit \`$SHA\` (\`$V\`)." \

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -108,3 +108,53 @@ jobs:
           echo "- Major tag \`$MAJOR\` now points at \`$V\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Consumers using \`azure/login@$MAJOR\` now get \`$V\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- The bad tag/branch/release were NOT deleted (delete manually if required)." >> "$GITHUB_STEP_SUMMARY"
+
+  open-selfpin-pr:
+    needs: rollback
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: master
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Roll back azure/login self-references and open PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          V: ${{ inputs.target_version }}
+        run: |
+          TARGET_MAJOR="${V%%.*}"   # v3.0.1 -> v3
+          # Only touch master's pins if they track the same major we are rolling back;
+          # a back-major (e.g. v2) rollback must not repoint master's current-major pins.
+          CURRENT_MAJOR=$(grep -rhoE 'uses:[[:space:]]+azure/login@[0-9a-f]+[[:space:]]*#[[:space:]]*v[0-9]+' .github/workflows | head -1 | grep -oE 'v[0-9]+$')
+          if [ -z "$CURRENT_MAJOR" ]; then
+            echo "No pinned azure/login self-references on master; nothing to roll back."
+            exit 0
+          fi
+          if [ "$CURRENT_MAJOR" != "$TARGET_MAJOR" ]; then
+            echo "Rollback target major ($TARGET_MAJOR) does not match master's pinned major ($CURRENT_MAJOR); skipping self-pin update."
+            exit 0
+          fi
+          SHA=$(git rev-parse "refs/tags/$V^{commit}")
+          for f in .github/workflows/*.yml .github/workflows/*.yaml; do
+            [ -e "$f" ] || continue
+            sed -i -E "s|(uses:[[:space:]]+azure/login@)[^[:space:]]+.*|\1${SHA} # ${V}|" "$f"
+          done
+          if git diff --quiet; then
+            echo "azure/login self-references already at $V."
+            exit 0
+          fi
+          BRANCH="chore/rollback-azure-login-$V"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git commit .github/workflows -m "chore: roll back azure/login self-references to $V"
+          git push --force-with-lease --set-upstream origin "$BRANCH"
+          gh pr create --base master --head "$BRANCH" \
+            --title "Roll back azure/login self-references to $V" \
+            --body "Automated post-rollback update: repoints \`azure/login@…\` in workflow files to the rolled-back release commit \`$SHA\` (\`$V\`)." \
+            || echo "PR for $BRANCH may already exist; skipping create."


### PR DESCRIPTION
## Summary

Automates release tagging via a repo-scoped **deploy key** (the one identity allowed to bypass the tag rulesets), keeps our `azure/login@<sha>` self-references current after each release, and adds a rotation reminder.

## Changes

- **`release.yml`** — `checkout` uses `ssh-key: RELEASE_DEPLOY_KEY`, so the release-branch push, version-tag create, and `v3` move go through the deploy key (needed to bypass the tag rulesets and to trigger downstream CI). New `open-selfpin-pr` job rewrites the `azure/login@<sha>` pins to the new release commit and opens a `chore/*` PR (uses `GITHUB_TOKEN`, not the key).
- **`rollback.yml`** — same `ssh-key` addition for the `v3` force-move.
- **`dependabot.yml`** — ignores `azure/login` (now owned by the release workflow) to avoid duplicate bump PRs; third-party actions still covered.
- **`deploy-key-rotation-reminder.yml`** (new) — opens an issue every 6 months (Jan/Jul) to rotate `RELEASE_DEPLOY_KEY`; idempotent, `issues: write` only.

## Deploy key

Repo-scoped SSH key, git-only, no API access. Private key stored as an **environment secret on `release`** (admin-gated). Only elevated power: bypass `tags-create-blocked` + `major-tags-move-blocked`. Not granted bypass on minor/delete rulesets; never writes `master` or opens PRs.

## Requires admin setup before functional

1. Create deploy key + `RELEASE_DEPLOY_KEY` env secret on `release`.
2. Add key as bypass actor on `tags-create-blocked` + `major-tags-move-blocked`.
3. Enable "Allow Actions to create and approve PRs".
4. (Related) Add `releases/**` write-once ruleset.

## Testing

Deploy-key push/bypass validated end-to-end in the `azclitools-actions-test` sandbox (key push succeeds + triggers CI; `GITHUB_TOKEN` blocked), then cleaned up. YAML validated locally.
